### PR TITLE
reactive handover to all modules but enrichment

### DIFF
--- a/program/shinyApp/R/heatmap/server.R
+++ b/program/shinyApp/R/heatmap/server.R
@@ -12,9 +12,9 @@ heatmap_server <- function(id,omicType){
             selectInput(
               inputId = ns("anno_options"),
               label = "Choose the variable to color the samples after (Multiples are possible)",
-              choices = c(colnames(data_input_shiny()[[omicType]]$sample_table)),
+              choices = c(colnames(data_input_shiny()[[omicType()]]$sample_table)),
               multiple = T , # would be cool if true, to be able to merge vars ?!,
-              selected= c(colnames(data_input_shiny()[[omicType]]$sample_table))[1]
+              selected= c(colnames(data_input_shiny()[[omicType()]]$sample_table))[1]
             )
           })
           output$row_anno_options_ui <- renderUI({
@@ -22,9 +22,9 @@ heatmap_server <- function(id,omicType){
             selectInput(
               inputId = ns("row_anno_options"),
               label = "Choose the variable to color the rows after (Multiples are possible)",
-              choices = c(colnames(data_input_shiny()[[omicType]]$annotation_rows)),
+              choices = c(colnames(data_input_shiny()[[omicType()]]$annotation_rows)),
               multiple = T, # would be cool if true, to be able to merge vars ?!,
-              selected = c(colnames(data_input_shiny()[[omicType]]$annotation_rows))[length(c(colnames(data_input_shiny()[[omicType]]$annotation_rows)))]
+              selected = c(colnames(data_input_shiny()[[omicType()]]$annotation_rows))[length(c(colnames(data_input_shiny()[[omicType()]]$annotation_rows)))]
             )
           })
           output$row_label_options_ui <- renderUI({
@@ -33,7 +33,7 @@ heatmap_server <- function(id,omicType){
             selectInput(
               inputId = ns("row_label_options"),
               label = "Choose the label of rows",
-              choices = c(colnames(data_input_shiny()[[omicType]]$annotation_rows)),
+              choices = c(colnames(data_input_shiny()[[omicType()]]$annotation_rows)),
               multiple = F, # would be cool if true, to be able to merge vars ?!,
               selected=input$row_anno_options
             )
@@ -101,9 +101,9 @@ heatmap_server <- function(id,omicType){
             selectInput(
               inputId = ns("sample_annotation_types_cmp_heatmap"),
               label = "Choose type for LFC-based ordering",
-              choices = c(colnames(data_input_shiny()[[omicType]]$sample_table)),
+              choices = c(colnames(data_input_shiny()[[omicType()]]$sample_table)),
               multiple = F,
-              selected = c(colnames(data_input_shiny()[[omicType]]$sample_table))[1]
+              selected = c(colnames(data_input_shiny()[[omicType()]]$sample_table))[1]
             )
           })
           output$Groups2Compare_ref_heatmap_ui <- renderUI({
@@ -111,9 +111,9 @@ heatmap_server <- function(id,omicType){
             selectInput(
               inputId = ns("Groups2Compare_ref_heatmap"),
               label = "Choose reference of log2 FoldChange",
-              choices = unique(data_input_shiny()[[omicType]]$sample_table[,input$sample_annotation_types_cmp_heatmap]),
+              choices = unique(data_input_shiny()[[omicType()]]$sample_table[,input$sample_annotation_types_cmp_heatmap]),
               multiple = F ,
-              selected = unique(data_input_shiny()[[omicType]]$sample_table[,input$sample_annotation_types_cmp_heatmap])[1]
+              selected = unique(data_input_shiny()[[omicType()]]$sample_table[,input$sample_annotation_types_cmp_heatmap])[1]
             )
           })
           output$Groups2Compare_treat_heatmap_ui <- renderUI({
@@ -121,9 +121,9 @@ heatmap_server <- function(id,omicType){
             selectInput(
               inputId = ns("Groups2Compare_treat_heatmap"),
               label = "Choose treatment group of log2 FoldChange",
-              choices = unique(data_input_shiny()[[omicType]]$sample_table[,input$sample_annotation_types_cmp_heatmap]),
+              choices = unique(data_input_shiny()[[omicType()]]$sample_table[,input$sample_annotation_types_cmp_heatmap]),
               multiple = F ,
-              selected = unique(data_input_shiny()[[omicType]]$sample_table[,input$sample_annotation_types_cmp_heatmap])[2]
+              selected = unique(data_input_shiny()[[omicType()]]$sample_table[,input$sample_annotation_types_cmp_heatmap])[2]
             )
           })
           output$psig_threhsold_heatmap_ui <- renderUI({
@@ -168,8 +168,8 @@ heatmap_server <- function(id,omicType){
             selectInput(
               inputId = ns("anno_options_heatmap"),
               label = "Choose the variable to select the rows after (Multiples are not possible)",
-              choices = c(colnames(selectedData_processed()[[omicType]]$annotation_rows)),
-              selected=colnames(selectedData_processed()[[omicType]]$annotation_rows)[1],
+              choices = c(colnames(selectedData_processed()[[omicType()]]$annotation_rows)),
+              selected=colnames(selectedData_processed()[[omicType()]]$annotation_rows)[1],
               multiple = F # would be cool if true, to be able to merge vars ?!,
             )
           })
@@ -178,7 +178,7 @@ heatmap_server <- function(id,omicType){
             selectInput(
               inputId = ns("row_anno_options_heatmap"),
               label = "Which entities to use?",
-              choices = c("all",unique(selectedData_processed()[[omicType]]$annotation_rows[,input$anno_options_heatmap])),
+              choices = c("all",unique(selectedData_processed()[[omicType()]]$annotation_rows[,input$anno_options_heatmap])),
               selected="all",
               multiple = T
             )
@@ -205,7 +205,7 @@ heatmap_server <- function(id,omicType){
 
       observeEvent(toListen2Heatmap(),{
         req(input$Do_Heatmap[1]>0)
-        req(omicType,input$row_selection_options,input$anno_options,input$row_label_options)
+        req(omicType(),input$row_selection_options,input$anno_options,input$row_label_options)
         req(selectedData_processed())
         print("Heatmap on selected Data")
         # Value need to be setted in case there is nothing to plot to avoid crash
@@ -216,7 +216,7 @@ heatmap_server <- function(id,omicType){
                         "#fdbf6f", "#ff7f00", "#fb9a99", "#e31a1c")
         customTitleHeatmap <- paste0(
           "Heatmap - ",
-          omicType,"-",
+          omicType(),"-",
           paste0("entities:",input$row_selection,collapse = "_"),
           "-samples",
           ifelse(any(input$sample_selection!="all"),paste0(" (with: ",paste0(input$sample_selection,collapse = ", "),")"),""),
@@ -227,8 +227,8 @@ heatmap_server <- function(id,omicType){
         print(customTitleHeatmap)
         mycolors <- list()
         if(length(input$anno_options)==1){
-          if(length(unique(data2Plot[[omicType]]$sample_table[,input$anno_options])) <= 8){
-            names(colorTheme) <- unique(data2Plot[[omicType]]$sample_table[,input$anno_options])
+          if(length(unique(data2Plot[[omicType()]]$sample_table[,input$anno_options])) <= 8){
+            names(colorTheme) <- unique(data2Plot[[omicType()]]$sample_table[,input$anno_options])
             colorTheme <- colorTheme[!is.na(names(colorTheme))]
             mycolors[[input$anno_options]] <- colorTheme
           }
@@ -285,11 +285,11 @@ heatmap_server <- function(id,omicType){
         TopK2Show <- ifelse(any(input$row_selection_options=="TopK"),input$TopK,NA)
         
         if(any(input$row_selection_options=="all")){
-          data2HandOver <- selectedData_processed()[[omicType]]$Matrix
+          data2HandOver <- selectedData_processed()[[omicType()]]$Matrix
         }else{
           print(input$row_selection_options)
           data2HandOver <- entitieSelection(
-            selectedData_processed()[[omicType]],
+            selectedData_processed()[[omicType()]],
             type = input$row_selection_options,
             additionalInput_row_anno = additionalInput_row_anno,
             additionalInput_row_anno_factor = additionalInput_row_anno_factor,
@@ -315,10 +315,10 @@ heatmap_server <- function(id,omicType){
         # Dependent to plot raw data or LFC
         if(input$LFC_toHeatmap){
           ctrl_samples_idx <- which(
-            selectedData_processed()[[omicType]]$sample_table[,input$sample_annotation_types_cmp_heatmap]%in%input$Groups2Compare_ref_heatmap
+            selectedData_processed()[[omicType()]]$sample_table[,input$sample_annotation_types_cmp_heatmap]%in%input$Groups2Compare_ref_heatmap
             )
           comparison_samples_idx <- which(
-            selectedData_processed()[[omicType]]$sample_table[,input$sample_annotation_types_cmp_heatmap]%in%input$Groups2Compare_treat_heatmap
+            selectedData_processed()[[omicType()]]$sample_table[,input$sample_annotation_types_cmp_heatmap]%in%input$Groups2Compare_treat_heatmap
             )
           if(length(comparison_samples_idx) <=1 | 
              length(ctrl_samples_idx)<=1){
@@ -326,24 +326,24 @@ heatmap_server <- function(id,omicType){
             doThis_flag <- F
           }
           if(input$PreProcessing_Procedure == "simpleCenterScaling"|
-             any(selectedData_processed()[[omicType]]$Matrix<0)){
+             any(selectedData_processed()[[omicType()]]$Matrix<0)){
             print("Remember do not use normal center + scaling (negative Values!)")
             output$Options_selected_out_3 <- renderText("Choose another preprocessing, as there are negative values!")
 
           }else if(doThis_flag){
-            print(dim(selectedData_processed()[[omicType]]$Matrix))
+            print(dim(selectedData_processed()[[omicType()]]$Matrix))
             Data2Plot <- getLFC(
-              data = data2Plot[[omicType]]$Matrix,
+              data = data2Plot[[omicType()]]$Matrix,
               ctrl_samples_idx = ctrl_samples_idx,
               comparison_samples_idx = comparison_samples_idx
               )
             # adjust sample annotation
             # if the value is accross all group-members the same keep 1 col otherwise remove
-            keep_ctrl <- apply(data2Plot[[omicType]]$sample_table[ctrl_samples_idx,],2,function (x) length(unique(x))==1)
-            keep_treat <- apply(data2Plot[[omicType]]$sample_table[comparison_samples_idx,],2,function (x) length(unique(x))==1)
+            keep_ctrl <- apply(data2Plot[[omicType()]]$sample_table[ctrl_samples_idx,],2,function (x) length(unique(x))==1)
+            keep_treat <- apply(data2Plot[[omicType()]]$sample_table[comparison_samples_idx,],2,function (x) length(unique(x))==1)
             
             # keep  only if both TRUE
-            keep_final <- names(data2Plot[[omicType]]$sample_table)[keep_ctrl & keep_treat]
+            keep_final <- names(data2Plot[[omicType()]]$sample_table)[keep_ctrl & keep_treat]
             
             ## do pheatmap
             #remove anything non sig
@@ -353,7 +353,7 @@ heatmap_server <- function(id,omicType){
                           seq(max(Data2Plot$LFC)/paletteLength, max(Data2Plot$LFC), length.out=floor(paletteLength/2)))
             
             scenario <- 10
-            annotation_col <- data2Plot[[omicType]]$annotation_rows[,input$row_anno_options,drop=F]
+            annotation_col <- data2Plot[[omicType()]]$annotation_rows[,input$row_anno_options,drop=F]
             heatmap_plot <- pheatmap(
               t(Data2Plot[,"LFC",drop=F]),
               main=gsub("^Heatmap","Heatmap_LFC",customTitleHeatmap),
@@ -365,7 +365,7 @@ heatmap_server <- function(id,omicType){
               # cutree_cols = 4,
               #fontsize = font.size,
               annotation_col = annotation_col,
-              #annotation_row = data2Plot[[omicType]]$annotation_rows[,input$row_anno_options,drop=F],
+              #annotation_row = data2Plot[[omicType()]]$annotation_rows[,input$row_anno_options,drop=F],
               #annotation_colors = mycolors,
               silent = F,
               breaks = myBreaks,
@@ -380,11 +380,11 @@ heatmap_server <- function(id,omicType){
               data2HandOver <- data2HandOver[-idx_of_nas,] 
             }
 
-            annotation_col <- selectedData_processed()[[omicType]]$sample_table[-idx_of_nas,input$anno_options,drop=F]
-            annotation_row <- selectedData_processed()[[omicType]]$annotation_rows[-idx_of_nas,input$row_anno_options,drop=F]
+            annotation_col <- selectedData_processed()[[omicType()]]$sample_table[-idx_of_nas,input$anno_options,drop=F]
+            annotation_row <- selectedData_processed()[[omicType()]]$annotation_rows[-idx_of_nas,input$row_anno_options,drop=F]
           }else{
-            annotation_col <- selectedData_processed()[[omicType]]$sample_table[,input$anno_options,drop=F]
-            annotation_row <- selectedData_processed()[[omicType]]$annotation_rows[,input$row_anno_options,drop=F]
+            annotation_col <- selectedData_processed()[[omicType()]]$sample_table[,input$anno_options,drop=F]
+            annotation_row <- selectedData_processed()[[omicType()]]$annotation_rows[,input$row_anno_options,drop=F]
           }
           clusterRowspossible <- ifelse(nrow(as.matrix(data2HandOver))>1,input$cluster_rows,F)
           print(input$anno_options)
@@ -396,7 +396,7 @@ heatmap_server <- function(id,omicType){
             as.matrix(data2HandOver),
             main = customTitleHeatmap,
             show_rownames=ifelse(nrow(data2HandOver)<=input$row_label_no,TRUE,FALSE),
-            labels_row = selectedData_processed_df[[omicType]]$annotation_rows[rownames(data2HandOver),input$row_label_options],
+            labels_row = selectedData_processed_df[[omicType()]]$annotation_rows[rownames(data2HandOver),input$row_label_options],
             show_colnames=TRUE,
             cluster_cols = input$cluster_cols,
             cluster_rows = clusterRowspossible,
@@ -534,7 +534,7 @@ heatmap_server <- function(id,omicType){
           FLAG_nonUnique_Heatmap<<-F
           NA
         }else{
-          mergedData <- merge(data2HandOver,selectedData_processed()[[omicType]]$annotation_rows,
+          mergedData <- merge(data2HandOver,selectedData_processed()[[omicType()]]$annotation_rows,
                               by = 0, 
                               all.x = T,
                               all.y = F,

--- a/program/shinyApp/R/pca/server.R
+++ b/program/shinyApp/R/pca/server.R
@@ -38,7 +38,7 @@ pca_Server <- function(id, omic_type, row_select){
         selectInput(
           inputId = ns("coloring_options"),
           label = "Choose the variable to color the samples after",
-          choices = c(colnames(data_input_shiny()[[omic_type]]$sample_table)),
+          choices = c(colnames(data_input_shiny()[[omic_type()]]$sample_table)),
           multiple = F # would be cool if true, to be able to merge vars ?!
         )
       })
@@ -47,7 +47,7 @@ pca_Server <- function(id, omic_type, row_select){
         selectInput(
           inputId = ns("PCA_anno_tooltip"),
           label = "Select the anno to be shown at tooltip",
-          choices = c(colnames(data_input_shiny()[[omic_type]]$sample_table)),
+          choices = c(colnames(data_input_shiny()[[omic_type()]]$sample_table)),
           multiple = F
         )
       })
@@ -56,7 +56,7 @@ pca_Server <- function(id, omic_type, row_select){
         selectInput(
           inputId = ns("EntitieAnno_Loadings"),
           label = "Select the annotype shown at y-axis",
-          choices = c(colnames(data_input_shiny()[[omic_type]]$annotation_rows)),
+          choices = c(colnames(data_input_shiny()[[omic_type()]]$annotation_rows)),
           multiple = F
         )
       })
@@ -75,7 +75,7 @@ pca_Server <- function(id, omic_type, row_select){
       })
       observeEvent(toListen2PCA(),{
         req(
-          omic_type,
+          omic_type(),
           input$x_axis_selection,
           input$y_axis_selection,
           input$coloring_options
@@ -83,10 +83,10 @@ pca_Server <- function(id, omic_type, row_select){
 
         print("PCA analysis on pre-selected data")
         customTitle <- paste0(
-          "PCA - ", omic_type, "-",
-          paste0("entities:",row_select,collapse = "_"),
+          "PCA - ", omic_type(), "-",
+          paste0("entities:",row_select(),collapse = "_"),
           "-samples",
-          ifelse(any(input$sample_selection!="all"),paste0(" (with: ",paste0(input$sample_selection,collapse = ", "),")"),"")
+          ifelse(any(input$sample_selection != "all"),paste0(" (with: ",paste0(input$sample_selection,collapse = ", "),")"),"")
           , "-preprocessing: ",
           input$PreProcessing_Procedure
         )
@@ -94,7 +94,7 @@ pca_Server <- function(id, omic_type, row_select){
 
         # PCA
         pca <- prcomp(
-          as.data.frame(t(selectedData_processed()[[omic_type]]$Matrix)),
+          as.data.frame(t(selectedData_processed()[[omic_type()]]$Matrix)),
           center = T,
           scale. = FALSE
         )
@@ -105,7 +105,7 @@ pca_Server <- function(id, omic_type, row_select){
         percentVar <- round(100 * explVar, digits=1)
 
         # Define data for plotting
-        pcaData <- data.frame(pca$x,selectedData_processed()[[omic_type]]$sample_table)
+        pcaData <- data.frame(pca$x,selectedData_processed()[[omic_type()]]$sample_table)
 
         # Coloring Options
         print(input$coloring_options)
@@ -186,7 +186,7 @@ pca_Server <- function(id, omic_type, row_select){
             geom_point(size =3)+
             scale_color_manual(values = colorTheme,
                                name = input$coloring_options)
-          scenario <-3
+          scenario <- 3
         }
 
         pca_plot_final <- pca_plot+
@@ -240,10 +240,10 @@ pca_Server <- function(id, omic_type, row_select){
           df_out_r$global_ID <- rownames(df_out_r)
           df_out_r$chosenAnno <- rownames(df_out_r)
           if(!is.null(input$EntitieAnno_Loadings)){
-            req(data_input_shiny()[[omic_type]])
+            req(data_input_shiny()[[omic_type()]])
             df_out_r$chosenAnno <- factor(
-              make.unique(as.character(data_input_shiny()[[omic_type]]$annotation_rows[rownames(df_out_r),input$EntitieAnno_Loadings])),
-              levels = make.unique(as.character(data_input_shiny()[[omic_type]]$annotation_rows[rownames(df_out_r),input$EntitieAnno_Loadings]))
+              make.unique(as.character(data_input_shiny()[[omic_type()]]$annotation_rows[rownames(df_out_r),input$EntitieAnno_Loadings])),
+              levels = make.unique(as.character(data_input_shiny()[[omic_type()]]$annotation_rows[rownames(df_out_r),input$EntitieAnno_Loadings]))
               )
           }
 
@@ -275,7 +275,7 @@ pca_Server <- function(id, omic_type, row_select){
         global_Vars$PCA_plot <- pca_plot_final # somehow does not update ? or just return the latest?
         global_Vars$PCA_customTitle <- customTitle
         global_Vars$PCA_coloring <- input$coloring_options
-        global_Vars$PCA_noLoadings <- ifelse(input$Show_loadings=="Yes",length(TopK),0)
+        global_Vars$PCA_noLoadings <- ifelse(input$Show_loadings == "Yes",length(TopK),0)
 
         output$getR_Code_PCA <- downloadHandler(
           filename = function(){
@@ -417,10 +417,10 @@ pca_Server <- function(id, omic_type, row_select){
           )
         LoadingsDF$entitie <- factor(LoadingsDF$entitie,levels = rownames(LoadingsDF))
         if(!is.null(input$EntitieAnno_Loadings)){
-          req(data_input_shiny()[[omic_type]])
+          req(data_input_shiny()[[omic_type()]])
           LoadingsDF$entitie=factor(
-            make.unique(as.character(data_input_shiny()[[omic_type]]$annotation_rows[rownames(LoadingsDF),input$EntitieAnno_Loadings])),
-            levels = make.unique(as.character(data_input_shiny()[[omic_type]]$annotation_rows[rownames(LoadingsDF),input$EntitieAnno_Loadings]))
+            make.unique(as.character(data_input_shiny()[[omic_type()]]$annotation_rows[rownames(LoadingsDF),input$EntitieAnno_Loadings])),
+            levels = make.unique(as.character(data_input_shiny()[[omic_type()]]$annotation_rows[rownames(LoadingsDF),input$EntitieAnno_Loadings]))
             )
         }
 

--- a/program/shinyApp/R/single_gene_visualisation/server.R
+++ b/program/shinyApp/R/single_gene_visualisation/server.R
@@ -19,7 +19,7 @@ single_gene_visualisation_server <- function(id,omicType){
         selectInput(
           inputId = ns("accross_condition"),
           label = "Choose the groups to show the data for",
-          choices = unique(colnames(data_input_shiny()[[omicType]]$sample_table)),
+          choices = unique(colnames(data_input_shiny()[[omicType()]]$sample_table)),
           multiple = F
         )
       })
@@ -38,7 +38,7 @@ single_gene_visualisation_server <- function(id,omicType){
         selectInput(
           inputId = ns("Select_GeneAnno"),
           label = "Select Annotation you want to select an entitie from",
-          choices = colnames(data_input_shiny()[[omicType]]$annotation_rows), # for TESTING restricting to top 10
+          choices = colnames(data_input_shiny()[[omicType()]]$annotation_rows), # for TESTING restricting to top 10
           multiple = F 
         )
       })
@@ -48,7 +48,7 @@ single_gene_visualisation_server <- function(id,omicType){
         selectInput(
           inputId = ns("Select_Gene"),
           label = "Select the Gene from the list",
-          choices = unique(data_input_shiny()[[omicType]]$annotation_rows[,input$Select_GeneAnno]),
+          choices = unique(data_input_shiny()[[omicType()]]$annotation_rows[,input$Select_GeneAnno]),
           multiple = F 
         )
       })
@@ -58,9 +58,9 @@ single_gene_visualisation_server <- function(id,omicType){
         req(input$Select_GeneAnno)
         req(input$type_of_data_gene)
         if(input$type_of_data_gene == "raw"){
-          annoToSelect=c(data_input_shiny()[[omicType]]$sample_table[,input$accross_condition])
+          annoToSelect=c(data_input_shiny()[[omicType()]]$sample_table[,input$accross_condition])
         }else{
-          annoToSelect=c(selectedData_processed()[[omicType]]$sample_table[,input$accross_condition])
+          annoToSelect=c(selectedData_processed()[[omicType()]]$sample_table[,input$accross_condition])
         }
         
         if(length(annoToSelect) == length(unique(annoToSelect))){
@@ -95,12 +95,12 @@ single_gene_visualisation_server <- function(id,omicType){
         GeneDataFlag=F
         # Select data for the gene based on gene Selection & group Selection
         if(input$type_of_data_gene == "preprocessed"){
-          if(input$Select_Gene %in% selectedData_processed()[[omicType]]$annotation_rows[,input$Select_GeneAnno]){
+          if(input$Select_Gene %in% selectedData_processed()[[omicType()]]$annotation_rows[,input$Select_GeneAnno]){
             #get IDX to data
-            idx_selected <- which(input$Select_Gene == selectedData_processed()[[omicType]]$annotation_rows[,input$Select_GeneAnno])
-            GeneData <- as.data.frame(t(selectedData_processed()[[omicType]]$Matrix[idx_selected,,drop=F]))
+            idx_selected <- which(input$Select_Gene == selectedData_processed()[[omicType()]]$annotation_rows[,input$Select_GeneAnno])
+            GeneData <- as.data.frame(t(selectedData_processed()[[omicType()]]$Matrix[idx_selected,,drop=F]))
             print(input$accross_condition)
-            GeneData$anno <- selectedData_processed()[[omicType]]$sample_table[,input$accross_condition]
+            GeneData$anno <- selectedData_processed()[[omicType()]]$sample_table[,input$accross_condition]
             GeneDataFlag <- T
           }else{
             print("different Gene")
@@ -109,12 +109,12 @@ single_gene_visualisation_server <- function(id,omicType){
           
           
         }else if(input$type_of_data_gene == "raw" ){
-          if(input$Select_Gene %in% data_input_shiny()[[omicType]]$annotation_rows[,input$Select_GeneAnno]){
+          if(input$Select_Gene %in% data_input_shiny()[[omicType()]]$annotation_rows[,input$Select_GeneAnno]){
             #get IDX to data
-            idx_selected <- which(input$Select_Gene == data_input_shiny()[[omicType]]$annotation_rows[,input$Select_GeneAnno])
-            GeneData <- as.data.frame(t(data_input_shiny()[[omicType]]$Matrix[idx_selected,,drop=F]))
-            GeneData$anno <- data_input_shiny()[[omicType]]$sample_table[,input$accross_condition]
-            print(dim(data_input_shiny()[[omicType]]$Matrix))
+            idx_selected <- which(input$Select_Gene == data_input_shiny()[[omicType()]]$annotation_rows[,input$Select_GeneAnno])
+            GeneData <- as.data.frame(t(data_input_shiny()[[omicType()]]$Matrix[idx_selected,,drop=F]))
+            GeneData$anno <- data_input_shiny()[[omicType()]]$sample_table[,input$accross_condition]
+            print(dim(data_input_shiny()[[omicType()]]$Matrix))
             GeneDataFlag <- T
           }else{
             GeneDataFlag <- F

--- a/program/shinyApp/R/volcano_plot/server.R
+++ b/program/shinyApp/R/volcano_plot/server.R
@@ -12,7 +12,7 @@ volcano_Server <- function(id, omic_type){
         selectInput(
           inputId = ns("sample_annotation_types_cmp"),
           label = "Choose type for LFC comparison",
-          choices = c(colnames(data_input_shiny()[[omic_type]]$sample_table)),
+          choices = c(colnames(data_input_shiny()[[omic_type()]]$sample_table)),
           multiple = F ,
           selected = NULL
         )
@@ -23,21 +23,21 @@ volcano_Server <- function(id, omic_type){
         selectInput(
           inputId = ns("Groups2Compare_ref"),
           label = "Choose reference of log2 FoldChange",
-          choices = unique(data_input_shiny()[[omic_type]]$sample_table[,input$sample_annotation_types_cmp]),
+          choices = unique(data_input_shiny()[[omic_type()]]$sample_table[,input$sample_annotation_types_cmp]),
           multiple = F ,
-          selected = unique(data_input_shiny()[[omic_type]]$sample_table[,input$sample_annotation_types_cmp])[1]
+          selected = unique(data_input_shiny()[[omic_type()]]$sample_table[,input$sample_annotation_types_cmp])[1]
         )
       })
       output$Groups2Compare_treat_ui <- renderUI({
         req(data_input_shiny())
         req(input$sample_annotation_types_cmp)
-        print(data_input_shiny()[[omic_type]]$sample_table[,input$sample_annotation_types_cmp])
+        print(data_input_shiny()[[omic_type()]]$sample_table[,input$sample_annotation_types_cmp])
         selectInput(
           inputId = ns("Groups2Compare_treat"),
           label = "Choose treatment group of log2 FoldChange",
-          choices = unique(data_input_shiny()[[omic_type]]$sample_table[,input$sample_annotation_types_cmp]),
+          choices = unique(data_input_shiny()[[omic_type()]]$sample_table[,input$sample_annotation_types_cmp]),
           multiple = F ,
-          selected = unique(data_input_shiny()[[omic_type]]$sample_table[,input$sample_annotation_types_cmp])[2]
+          selected = unique(data_input_shiny()[[omic_type()]]$sample_table[,input$sample_annotation_types_cmp])[2]
         )
       })
       output$psig_threhsold_ui <- renderUI({
@@ -66,7 +66,7 @@ volcano_Server <- function(id, omic_type){
         selectInput(
           inputId = ns("VOLCANO_anno_tooltip"),
           label = "Select the anno to be shown at tooltip",
-          choices = c(colnames(data_input_shiny()[[omic_type]]$annotation_rows)),
+          choices = c(colnames(data_input_shiny()[[omic_type()]]$annotation_rows)),
           multiple = F
         )
       })
@@ -83,7 +83,7 @@ volcano_Server <- function(id, omic_type){
       ## Do Volcano----
       observeEvent(toListen2Volcano(),{
         req(
-          omic_type,
+          omic_type(),
           isTruthy(selectedData_processed()),
           input$sample_annotation_types_cmp,
           input$psig_threhsold,
@@ -93,10 +93,10 @@ volcano_Server <- function(id, omic_type){
         print("Volcano analysis on pre-selected data")
         print(input$sample_annotation_types_cmp)
         ctrl_samples_idx <- which(
-          selectedData_processed()[[omic_type]]$sample_table[,input$sample_annotation_types_cmp] %in% input$Groups2Compare_ref
+          selectedData_processed()[[omic_type()]]$sample_table[,input$sample_annotation_types_cmp] %in% input$Groups2Compare_ref
           )
         comparison_samples_idx <- which(
-          selectedData_processed()[[omic_type]]$sample_table[,input$sample_annotation_types_cmp] %in% input$Groups2Compare_treat
+          selectedData_processed()[[omic_type()]]$sample_table[,input$sample_annotation_types_cmp] %in% input$Groups2Compare_treat
           )
 
         if(length(comparison_samples_idx) <= 1 |
@@ -116,15 +116,15 @@ volcano_Server <- function(id, omic_type){
               print("Data was logged already => delog, take FC and log ?!")
               if(pre_processing_procedure == "ln"){
                 data2Volcano <- as.data.frame(exp(
-                  selectedData_processed()[[omic_type]]$Matrix
+                  selectedData_processed()[[omic_type()]]$Matrix
                   ))
               }else{
                 data2Volcano <- as.data.frame(10^(
-                  selectedData_processed()[[omic_type]]$Matrix
+                  selectedData_processed()[[omic_type()]]$Matrix
                   ))
               }
           }else{
-              data2Volcano <- selectedData_processed()[[omic_type]]$Matrix
+              data2Volcano <- selectedData_processed()[[omic_type()]]$Matrix
           }
           if(any(data2Volcano == 0)){
             #macht es mehr sinn nur die nullen + eps zu machen oder lieber alle daten punkte + eps?
@@ -139,7 +139,7 @@ volcano_Server <- function(id, omic_type){
             p_sig_threshold = input$psig_threhsold,
             LFC_threshold = input$lfc_threshold,
             annotation_add = input$VOLCANO_anno_tooltip,
-            annoData = selectedData_processed()[[omic_type]]$annotation_rows
+            annoData = selectedData_processed()[[omic_type()]]$annotation_rows
             )
           colorScheme <- c("#cf0e5b","#939596")
           names(colorScheme) <- c("significant","non-significant")
@@ -187,7 +187,7 @@ volcano_Server <- function(id, omic_type){
           # add annotation to Table
           LFCTable <- merge(
             LFCTable,
-            selectedData_processed()[[omic_type]]$annotation_rows,
+            selectedData_processed()[[omic_type()]]$annotation_rows,
             by=0,
             all.x=TRUE,
             all.y=F)

--- a/program/shinyApp/server.R
+++ b/program/shinyApp/server.R
@@ -899,8 +899,8 @@ server <- function(input,output,session){
   
   output$debug <- renderText(dim(selectedData_processed()[[input$omicType]]$Matrix))
   # PCA module
-  pca_Server(id="PCA", omic_type = input$omicType, row_select = input$row_selection)
-  volcano_Server(id="Volcano", omic_type = input$omicType)
+  pca_Server(id="PCA", omic_type = reactive(input$omicType), row_select = reactive(input$row_selection))
+  volcano_Server(id="Volcano", omic_type = reactive(input$omicType))
 
 #   # Volcano Plot----
 # ## UI Section----
@@ -1240,13 +1240,13 @@ server <- function(input,output,session){
 #   })
 
 # # Heatmap ----
-  heatmap_server(id = 'Heatmap',omicType = input$omicType)
+  heatmap_server(id = 'Heatmap',omicType = reactive(input$omicType))
   
 
 # Single Gene Visualisations ----
   single_gene_visualisation_server(
     id = "single_gene_visualisation",
-    omicType = input$omicType
+    omicType = reactive(input$omicType)
     )
 # ## Ui section ----
 #   output$type_of_data_gene_ui=renderUI({


### PR DESCRIPTION
This is a crucial fix, has the previous version had just always handover the default `omic_type` as it was not re-evaluated based on the user's input.