### PR TITLE
First time user help

### DIFF
--- a/.github/workflows/start_check.yaml
+++ b/.github/workflows/start_check.yaml
@@ -103,6 +103,7 @@ jobs:
         if (result == "Success") {
           cat("Test passed")
         } else {
+        cat(result)
            cat("Test failed: Output is 'failure'\n")
           quit(status = 1)
         }

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ nav_exclude: true
 
 If you are looking for the web app, please visit: 🌐 [cOmicsART Web App](https://shiny.iaas.uni-bonn.de/cOmicsArt/)
 
-Otherwise, you can navigate through the documentation using the sidebar on the left. If you’re searching for something specific, try using the search bar at the top. 🔍 It can search through the entire documentation and guide you to the relevant section.
+Otherwise, you can navigate through the documentation using the sidebar on the left. **If you’re searching for something specific, try using the search bar at the top.** 🔍 It can search through the entire documentation and guide you to the relevant section.
 
 Have fun exploring! 🎉
 

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -11,7 +11,7 @@ nav_order: 1
 
 If you are looking for the web app, please visit: 🌐 [cOmicsART Web App](https://shiny.iaas.uni-bonn.de/cOmicsArt/)
 
-Otherwise, you can navigate through the documentation using the sidebar on the left. If you’re searching for something specific, try using the search bar at the top. 🔍 It can search through the entire documentation and guide you to the relevant section.
+Otherwise, you can navigate through the documentation using the sidebar on the left. **If you’re searching for something specific, try using the search bar at the top.** 🔍 It can search through the entire documentation and guide you to the relevant section.
 
 **Have fun exploring!** 🎉
 

--- a/program/shinyApp/R/C.R
+++ b/program/shinyApp/R/C.R
@@ -1,6 +1,7 @@
 # Keep here for now. Needs to be replaced i guess at some point.
 library(waiter)
 library(ggplot2)
+library(cicerone)
 ### Global Constants will be saved here
 NOTES_PlACEHOLDER <<- "Notes you want to take alongside the plot (will be saved in the report) \nYou can use markdown syntax for your notes "
 NOTES_HELP <<- HTML("<a href='https://www.markdownguide.org/cheat-sheet/' target='_blank'>Here you can find a Markdown Cheat Sheet</a> \n
@@ -241,7 +242,7 @@ LOADING_SCREEN <- tagList(
 
 
 
-guide <<- Cicerone$
+guide <<- cicerone::Cicerone$
   new(keyboard_control = TRUE)$
   step(
     el = "sidebar_help_tab",

--- a/program/shinyApp/R/C.R
+++ b/program/shinyApp/R/C.R
@@ -300,6 +300,11 @@ guide <<- Cicerone$
     As soon as the Pre-processing is done the analysis tabs will appear - those do not have to be completed in a specific order - they work independently from each other."
   )$
   step(
+    el = "firstQ",
+    title = "Question Marks",
+    description = "Click on theese to get more help on the particular tagged item. (Do not click on this during this guide, you can try it out afterwards) "
+  )$
+  step(
     el = "UsefulLinks",
     title = "Useful Links",
     description = "Here are two helpful links - the top one let's you get the automatic generated report. The bottom one redirects you to the extensive Documentation (opens a new tab). This links are always present."

--- a/program/shinyApp/R/C.R
+++ b/program/shinyApp/R/C.R
@@ -238,3 +238,59 @@ LOADING_SCREEN <- tagList(
     )
   )
 )
+
+
+
+guide <<- Cicerone$
+  new(keyboard_control = TRUE)$
+  step(
+    el = "sidebar_help_tab",
+    title = "Sidebar",
+    description = "This is the sidebar where you can select images and adjust settings. We will go through the elements step by step in a second.",
+  )$
+  step(
+    el = "mainPanel_help_tab",
+    title = "Main Panel",
+    description = "This is the main panel where you can view the output based on your input in the sidepanel. We will go through the elements step by step in a second."
+  )$
+  step(
+    el = "ImageSelectArea",
+    position = "right",
+    title = "Selecting the required options",
+    description = "In this little tutorial we have one parameter to set, which we can select from the dropdown menu. Click on the little arrow down to see the options. Select 'Youtube Tutorial'"
+  )$
+  step(
+    el = "horizontalLine",
+    title = "An important line",
+    description = "This line separates the sidebar. All options above this line require your input (selecting your desired option and pressing the 'GO!' button). All options below this line can be first left as they are. 
+    Their changes are directly applied to the output and do not require any re-computation. We will come back to those later."
+  )$
+  step(
+    el = "get_help",
+    title = "Starting the analysis",
+    description = "After you have selected your options (or sometimes stick with the pre-selected option) you have to press this button to ensure your selection is now actually carried out. Press it now to continue."
+  )$
+  step(
+    el ="mainPanel_help_tab",
+    title = "Main Panel",
+    position = "mid-center",
+    description = "Remember this? This is the main Panel. If you have selected Youtube Tutorial AND pressed the 'GO' button you will see a video here (You might want to watch it after this little guide to get introduced to the analysis features).
+    If you don't see a video here, you might have missed to press the 'GO' button or selected a different option. Click onto previous to correct your mistakes.
+    If you see the video click next."
+  )$
+  step(
+    el = "help_tab_info",
+    title = "Information",
+    description = "This grey box will contain information about the performed analysis. For example: It will notify you if the analysis was successful or if there were any warning. It is always a good idea to pay attention to the output here."
+  )$
+  step(
+    el = "NextPanel",
+    title = "Next Panel",
+    description = "This button will take you to the next panel where you can perfomr the Data upload and selection. You can navigate between the tabs by also simply clicking on the tab names. Click on 'Next' to see more details."
+  )$
+  step(
+    el ="tabsetPanel1",
+    title = "Analysis Tabs",
+    description = "These are the different tabs currently available. You can switch between them by clicking on the tab names. Each tab has a different purpose. Note, that more tabs will appear after the mandatory tabs Data selection and Pre-processing (not visible yet).
+    As soon as the Pre-processing is done the analysis tabs will appear - those do not have to be completed in a specific order - they work independently from each other."
+  )

--- a/program/shinyApp/R/C.R
+++ b/program/shinyApp/R/C.R
@@ -306,7 +306,7 @@ guide <<- cicerone::Cicerone$
   step(
     el = "UsefulLinks",
     title = "Very Useful Links",
-    description = HTML("The top one let's you get the automatic generated report.<br> The bottom leads you to the *extensive* Documentation. <br>Note, that you can search through the entire documentation for keywords! <br>This links are always present.")
+    description = HTML("The top one let's you get the automatic generated report.<br> The bottom leads you to the *extensive* Documentation. Click it now! <br>Note, that you can search through the entire documentation for keywords!")
   )$
   step(
     el = "WelcomePage_ui",

--- a/program/shinyApp/R/C.R
+++ b/program/shinyApp/R/C.R
@@ -284,13 +284,32 @@ guide <<- Cicerone$
     description = "This grey box will contain information about the performed analysis. For example: It will notify you if the analysis was successful or if there were any warning. It is always a good idea to pay attention to the output here."
   )$
   step(
+    el = "options",
+    title = "Parameters of the visulaization",
+    description = "The options below the line are applied to the generated output and hence immediately applied. Here, we have the options the adjust the width and height of the image. You can adjust them to your liking."
+  )$
+  step(
     el = "NextPanel",
     title = "Next Panel",
     description = "This button will take you to the next panel where you can perfomr the Data upload and selection. You can navigate between the tabs by also simply clicking on the tab names. Click on 'Next' to see more details."
   )$
   step(
-    el ="tabsetPanel1",
+    el = "tabsetPanel1",
     title = "Analysis Tabs",
     description = "These are the different tabs currently available. You can switch between them by clicking on the tab names. Each tab has a different purpose. Note, that more tabs will appear after the mandatory tabs Data selection and Pre-processing (not visible yet).
     As soon as the Pre-processing is done the analysis tabs will appear - those do not have to be completed in a specific order - they work independently from each other."
-  )
+  )$
+  step(
+    el = "UsefulLinks",
+    title = "Useful Links",
+    description = "Here are two helpful links - the top one let's you get the automatic generated report. The bottom one redirects you to the extensive Documentation (opens a new tab). This links are always present."
+  )$
+  step(
+    el = "WelcomePage_ui",
+    title = "The End",
+    description = "
+    <p>This is the end of the little tutorial. If you'd like more specific help about cOmicsART in action, check out the <a href='https://www.youtube.com/watch?v=pTGjtIYQOak&t=2s' target='_blank'>YouTube Tutorial</a>!</p>
+    <p>You can also visit the <a href='https://icb-dcm.github.io/cOmicsArt/' target='_blank'>documentation</a> for more detailed information.</p>
+    <p>After this tutorial, you should be able to find the link within the interface on your own. Happy exploring! <i class='fas fa-cat'></i> </p>
+  "
+    )

--- a/program/shinyApp/R/C.R
+++ b/program/shinyApp/R/C.R
@@ -251,11 +251,6 @@ guide <<- cicerone::Cicerone$
     description = HTML("Always start here to give cOmicsArt tasks.<br>We will go through the elements step by step."),
   )$
   step(
-    el = "mainPanel_help_tab",
-    title = "This is the main panel",
-    description = HTML("Here your output is displayed.<br>We will go through the elements step by step in a second.")
-  )$
-  step(
     el = "ImageSelectArea",
     position = "right",
     title = "Important parameters for the analysis",
@@ -272,15 +267,20 @@ guide <<- cicerone::Cicerone$
     description = "Press it now to continue."
   )$
   step(
-    el ="mainPanel_help_tab",
-    title = "Display of computed results",
-    position = "mid-center",
-    description = HTML("If you have selected Youtube Tutorial AND pressed the 'GO' button you will see a video here. <br>You might want to watch it after this little guide to get introduced to the analysis features).")
+    el = "mainPanel_help_tab",
+    title = "This is the main panel",
+    description = HTML("Here your output is displayed.<br>We will go through the elements step by step in a second.")
   )$
   step(
     el = "help_tab_info",
     title = "Information box",
     description = HTML("Contains information about the performed analysis.<br> For example: It will notify you if the analysis was successful or if there were any warning.<br> **It is always a good idea to pay attention to the output here.**")
+  )$
+  step(
+    el ="mainPanel_help_tab",
+    title = "Display of computed results",
+    position = "mid-center",
+    description = HTML("If you have selected Youtube Tutorial AND pressed the 'GO' button you will see a video here. <br>You might want to watch it after this little guide to get introduced to the analysis features).")
   )$
   step(
     el = "options",
@@ -306,7 +306,7 @@ guide <<- cicerone::Cicerone$
   step(
     el = "UsefulLinks",
     title = "Very Useful Links",
-    description = HTML("The top one let's you get the automatic generated report.<br> The bottom leads you to the *extensive* Documentation. Click it now! <br>Note, that you can search through the entire documentation for keywords!")
+description = HTML("The top one let's you get the automatic generated report.<br> The bottom leads you to the *extensive* Documentation. Click it now!")
   )$
   step(
     el = "WelcomePage_ui",

--- a/program/shinyApp/R/C.R
+++ b/program/shinyApp/R/C.R
@@ -246,75 +246,73 @@ guide <<- cicerone::Cicerone$
   new(keyboard_control = TRUE)$
   step(
     el = "sidebar_help_tab",
-    title = "Sidebar",
-    description = "This is the sidebar where you can select images and adjust settings. We will go through the elements step by step in a second.",
+    title = "This is the Sidebar",
+    position = "right",
+    description = HTML("Always start here to give cOmicsArt tasks.<br>We will go through the elements step by step."),
   )$
   step(
     el = "mainPanel_help_tab",
-    title = "Main Panel",
-    description = "This is the main panel where you can view the output based on your input in the sidepanel. We will go through the elements step by step in a second."
+    title = "This is the main panel",
+    description = HTML("Here your output is displayed.<br>We will go through the elements step by step in a second.")
   )$
   step(
     el = "ImageSelectArea",
     position = "right",
-    title = "Selecting the required options",
-    description = "In this little tutorial we have one parameter to set, which we can select from the dropdown menu. Click on the little arrow down to see the options. Select 'Youtube Tutorial'"
+    title = "Important parameters for the analysis",
+    description = HTML("Here we have 1 parameter to set.<br> Select 'Youtube Tutorial' from the dropdown menu.")
   )$
   step(
     el = "horizontalLine",
     title = "An important line",
-    description = "This line separates the sidebar. All options above this line require your input (selecting your desired option and pressing the 'GO!' button). All options below this line can be first left as they are. 
-    Their changes are directly applied to the output and do not require any re-computation. We will come back to those later."
+    description = HTML("All options above this line require re-computation, which is done by pressing the 'GO!' button. <br>All options below this line can be always changed.")
   )$
   step(
     el = "get_help",
-    title = "Starting the analysis",
-    description = "After you have selected your options (or sometimes stick with the pre-selected option) you have to press this button to ensure your selection is now actually carried out. Press it now to continue."
+    title = "The Go button evokes (re-)computation",
+    description = "Press it now to continue."
   )$
   step(
     el ="mainPanel_help_tab",
-    title = "Main Panel",
+    title = "Display of computed results",
     position = "mid-center",
-    description = "Remember this? This is the main Panel. If you have selected Youtube Tutorial AND pressed the 'GO' button you will see a video here (You might want to watch it after this little guide to get introduced to the analysis features).
-    If you don't see a video here, you might have missed to press the 'GO' button or selected a different option. Click onto previous to correct your mistakes.
-    If you see the video click next."
+    description = HTML("If you have selected Youtube Tutorial AND pressed the 'GO' button you will see a video here. <br>You might want to watch it after this little guide to get introduced to the analysis features).")
   )$
   step(
     el = "help_tab_info",
-    title = "Information",
-    description = "This grey box will contain information about the performed analysis. For example: It will notify you if the analysis was successful or if there were any warning. It is always a good idea to pay attention to the output here."
+    title = "Information box",
+    description = HTML("Contains information about the performed analysis.<br> For example: It will notify you if the analysis was successful or if there were any warning.<br> **It is always a good idea to pay attention to the output here.**")
   )$
   step(
     el = "options",
-    title = "Parameters of the visulaization",
-    description = "The options below the line are applied to the generated output and hence immediately applied. Here, we have the options the adjust the width and height of the image. You can adjust them to your liking."
+    title = "Here you can play around",
+    description = "Here, we have the options the adjust the width and height of the image.<br>A change will be reflected in the output immediately."
   )$
   step(
     el = "NextPanel",
     title = "Next Panel",
-    description = "This button will take you to the next panel where you can perfomr the Data upload and selection. You can navigate between the tabs by also simply clicking on the tab names. Click on 'Next' to see more details."
+    description = "This button will take you to the next panel to start."
   )$
   step(
     el = "tabsetPanel1",
-    title = "Analysis Tabs",
-    description = "These are the different tabs currently available. You can switch between them by clicking on the tab names. Each tab has a different purpose. Note, that more tabs will appear after the mandatory tabs Data selection and Pre-processing (not visible yet).
-    As soon as the Pre-processing is done the analysis tabs will appear - those do not have to be completed in a specific order - they work independently from each other."
+    title = "currently available Analysis Tabs",
+    description = HTML("You can switch between them by clicking on the tab names.<br>Note, that more tabs will appear after the mandatory tabs:<br>1. Data selection <br>2. Pre-processing (not visible yet).<br>
+    As soon as the Pre-processing is done the analysis tabs will appear. They work independently from each other.")
   )$
   step(
     el = "firstQ",
-    title = "Question Marks",
-    description = "Click on theese to get more help on the particular tagged item. (Do not click on this during this guide, you can try it out afterwards) "
+    title = "Question Marks lead to help",
+    description = "Useful to get more help on the particular tagged item."
   )$
   step(
     el = "UsefulLinks",
-    title = "Useful Links",
-    description = "Here are two helpful links - the top one let's you get the automatic generated report. The bottom one redirects you to the extensive Documentation (opens a new tab). Note, that you can search through the enitre documentation for keywords! This links are always present."
+    title = "Very Useful Links",
+    description = HTML("The top one let's you get the automatic generated report.<br> The bottom leads you to the *extensive* Documentation. <br>Note, that you can search through the entire documentation for keywords! <br>This links are always present.")
   )$
   step(
     el = "WelcomePage_ui",
     title = "The End",
     description = "
-    <p>This is the end of the little tutorial. If you'd like more specific help about cOmicsART in action, check out the <a href='https://www.youtube.com/watch?v=pTGjtIYQOak&t=2s' target='_blank'>YouTube Tutorial</a>!</p>
+    <p>This is the end of the little tutorial. If you'd like more specific help about cOmicsArt in action, check out the <a href='https://www.youtube.com/watch?v=pTGjtIYQOak&t=2s' target='_blank'>YouTube Tutorial</a>!</p>
     <p>You can also visit the <a href='https://icb-dcm.github.io/cOmicsArt/' target='_blank'>documentation</a> for more detailed information.</p>
     <p>After this tutorial, you should be able to find the link within the interface on your own. Happy exploring! <i class='fas fa-cat'></i> </p>
   "

--- a/program/shinyApp/R/C.R
+++ b/program/shinyApp/R/C.R
@@ -307,7 +307,7 @@ guide <<- Cicerone$
   step(
     el = "UsefulLinks",
     title = "Useful Links",
-    description = "Here are two helpful links - the top one let's you get the automatic generated report. The bottom one redirects you to the extensive Documentation (opens a new tab). This links are always present."
+    description = "Here are two helpful links - the top one let's you get the automatic generated report. The bottom one redirects you to the extensive Documentation (opens a new tab). Note, that you can search through the enitre documentation for keywords! This links are always present."
   )$
   step(
     el = "WelcomePage_ui",

--- a/program/shinyApp/R/data_selection/ui.R
+++ b/program/shinyApp/R/data_selection/ui.R
@@ -89,7 +89,7 @@ data_selection_sidebar_panel <- sidebarPanel(
           label = HTML('Upload data matrix <br/><small>(rows entities, cols samples) <br/><a href="airway-read-counts-LS.csv" download>Download example data (Transcriptomics, human)</a></small>'),
           accept = c(".csv", ".xlsx"),
           width = "80%"
-        ) %>% helper(type = "markdown", content = "DataSelection_MetaData"),
+        ) %>% helper(type = "markdown", content = "DataSelection_MetaData",style = "font-size: 24px;"),
         shiny::fileInput(
           inputId = "metadataInput",
           label = HTML("Upload your Meta Data Sheet <small>(currently replaces sample annotation)</small>"),

--- a/program/shinyApp/R/help_tab/ui.R
+++ b/program/shinyApp/R/help_tab/ui.R
@@ -1,0 +1,81 @@
+help_tab_sidebar_panel <- sidebarPanel(
+  id = "sidebar_help_tab",
+  h4("Sidebar"),
+  div(id="firstQ",p("Here you can select parameters which are important for your analysis.") %>% helper(type = "markdown", content = "helpTab_question")),
+  br(),
+  div(
+    id = "ImageSelectArea",
+    shinyWidgets::virtualSelectInput(
+  inputId = "ImageSelect",
+  label = "Select Image",
+  choices = c("nothing selected", "WelcomePage", "YouTube Tutorial"),
+  selected = "nothing selected"
+  )
+  ),
+  # Horizontal line
+  actionButton(
+     inputId = "get_help",
+     label = "GO!",
+     icon = icon('paper-plane'),
+     style = "color: #fffff; background-color: #90DBF4; border-color: #000000"
+   ),
+  div(
+    id = "horizontalLine",
+    hr(style = "border-top: 1px solid #858585;")
+    ),
+  div(
+    id = "options",
+    sliderInput("ImageWidth",
+                label="image width",
+                min = 50, 
+                max = 100, 
+                post  = " %", 
+                value = 100),
+    radioButtons(
+      inputId = "ImageHeight",
+      label = "image height",
+      choices = c("300px","400px", "500px"),
+      selected = "400px",
+    )
+  )
+  # Add some option that renders the 
+  )
+
+
+
+help_tab_main_panel <- mainPanel(
+  id = "mainPanel_help_tab",
+  h4("Main Panel",id = "Test"),
+  actionButton("start_tour", span(icon("hand-pointer"),"Tour around cOmicsArt"),style = "background-color: #00c6ff; color: white; padding: 10px 20px; border-radius: 10px; transition: transform 0.2s;"),
+  div(
+    id = "help_tab_info",
+    htmlOutput(outputId = "help_tab_info", container = pre),
+  ),
+  uiOutput(outputId = "WelcomePage_ui"),
+  # Line break for additional spacing
+  br(),
+  div(
+    # Action button
+    actionButton(
+      inputId = "NextPanel",
+      label = "Take me to the Analysis Start",
+      width = "100%",
+      icon = icon('rocket'),
+      style = "color: #050505; background-color: #70BF4F47; border-color: #000000"
+    )
+  )
+
+)
+
+
+help_tab_panel <- tabPanel(
+  title = "Welcome to comicsArt ",
+  id = "help_tab",
+  fluid = T,
+  h4("User Help"),
+  ################################################################################
+  # Data Selection
+  ################################################################################
+  help_tab_sidebar_panel,
+  help_tab_main_panel
+)

--- a/program/shinyApp/helpfiles/DataSelection_DataUploadFileInput.md
+++ b/program/shinyApp/helpfiles/DataSelection_DataUploadFileInput.md
@@ -1,6 +1,7 @@
 ### Data Upload via File Input
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/required-data-input.html" target="_blank">here</a>.
 
 With `Data upload` you can upload your data to the server via explicit csv files.<br>
 The files must be in the following format:<br>

--- a/program/shinyApp/helpfiles/DataSelection_MetaData.md
+++ b/program/shinyApp/helpfiles/DataSelection_MetaData.md
@@ -1,6 +1,7 @@
 ### Data Upload via File Input + Meta Data Sheet
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/required-data-input.html#starting-with-a-single-table-and-a-metadatasheet-" target="_blank">here</a>.
 
 With `Data upload` you can upload your data to the server via explicit csv files.<br>
 The files must be in the following format:<br>

--- a/program/shinyApp/helpfiles/DataSelection_RowSelection.md
+++ b/program/shinyApp/helpfiles/DataSelection_RowSelection.md
@@ -1,6 +1,7 @@
 ### Data Selection by Columns and Rows
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/selection.html#row-selection---biochemical-entities" target="_blank">here</a>.
 
 With `Row selection` you can choose the entities (e.g. genes) you want to include in the 
 analysis.

--- a/program/shinyApp/helpfiles/DataSelection_SummarizedExp.md
+++ b/program/shinyApp/helpfiles/DataSelection_SummarizedExp.md
@@ -1,6 +1,7 @@
 ### Data Upload via Precompiled Data
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/required-data-input.html#starting-with-an-rds-object" target="_blank">here</a>.
 
 With this option, you can upload previously used data. This allows you to upload 
 everything at once. Additionally, you can upload results from previous analyses. It is 

--- a/program/shinyApp/helpfiles/DataSelection_UploadInspection.md
+++ b/program/shinyApp/helpfiles/DataSelection_UploadInspection.md
@@ -1,6 +1,7 @@
 ### Data Quality Check - Visual Inspection
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/selection.html#file-input-%EF%B8%8F" target="_blank">here</a>.
 
 Using the `Upload visual inspection` tab, you can see the uploaded data and perform a 
 data quality check.

--- a/program/shinyApp/helpfiles/EA_GeneSets.md
+++ b/program/shinyApp/helpfiles/EA_GeneSets.md
@@ -1,5 +1,7 @@
 ## Gene Sets for Enrichment Analysis
 
+***
+
 You can choose a variety of gene sets for enrichment analysis. Here you find a 
 description of the gene sets. The information was taken from the
 [MSigDB database](https://www.gsea-msigdb.org/gsea/msigdb/collections.jsp), where you 

--- a/program/shinyApp/helpfiles/EA_Options.md
+++ b/program/shinyApp/helpfiles/EA_Options.md
@@ -1,6 +1,8 @@
 ## Enrichment Analysis Options
 
 ---
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/enrichment-analysis.html" target="_blank">here</a>.
+
 In cOmicsArt you can do either a gene set enrichment analysis or an over-representation analysis. The options for both analyses are described below.
 For more details read here on
 [Gene Set Enrichment Analysis](https://www.pnas.org/doi/abs/10.1073/pnas.0506580102) 

--- a/program/shinyApp/helpfiles/Heatmap_Aesthetics.md
+++ b/program/shinyApp/helpfiles/Heatmap_Aesthetics.md
@@ -1,6 +1,8 @@
 ## Heatmap Aesthetics Options
 
 ---
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/heatmap.html#aesthetics-options" target="_blank">here</a>.
+
 **1. Choose Variable to Color the Samples After:**
 
 - **Description:**

--- a/program/shinyApp/helpfiles/Heatmap_FurtherOptions.md
+++ b/program/shinyApp/helpfiles/Heatmap_FurtherOptions.md
@@ -1,6 +1,8 @@
 ## Log Fold Change (LFC) Ordering Options
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/heatmap.html#conditional-options-for-top-k" target="_blank">here</a>.
+
 **1. Choose Type for LFC-Based Ordering:**
 
 - **Description:**

--- a/program/shinyApp/helpfiles/Heatmap_Options.md
+++ b/program/shinyApp/helpfiles/Heatmap_Options.md
@@ -1,7 +1,7 @@
-
----
-
 ## Row Selection Options
+
+***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/heatmap.html#side-panel-" target="_blank">here</a>.
 
 **1. Row Selection Options:**
 

--- a/program/shinyApp/helpfiles/Heatmap_RowAnnoBased.md
+++ b/program/shinyApp/helpfiles/Heatmap_RowAnnoBased.md
@@ -1,6 +1,7 @@
 ## Additional Row Selection Options
 
 ---
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/heatmap.html#conditional-options-for-select-based-on-annotation" target="_blank">here</a>.
 
 These options only make sense if you selected `rowAnno_based` in the `Row Selection`. 
 They serve to filter the row entities which to include in the heatmap.

--- a/program/shinyApp/helpfiles/PCA_Choices.md
+++ b/program/shinyApp/helpfiles/PCA_Choices.md
@@ -1,6 +1,7 @@
 ## Principal Component Analysis (PCA) Options
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/pca.html#side-panel-" target="_blank">here</a>.
 
 A principal component analysis (PCA) is a linear dimensionality reduction technique to 
 visualize clusters within your data. For a small introduction on PCAs, please refer to 

--- a/program/shinyApp/helpfiles/PreProcessing_DESeqMain.md
+++ b/program/shinyApp/helpfiles/PreProcessing_DESeqMain.md
@@ -1,5 +1,8 @@
 ## DESeq Factor Choices
 
+***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/pre-processing.html" target="_blank">here</a>.
+
 ### Understanding the Design Matrix in DESeq2
 
 The design matrix in DESeq2 is a fundamental component used to specify the experimental design of your RNA-seq dataset. It helps in determining the relationship between the observed counts and the experimental conditions. Here's a detailed explanation:

--- a/program/shinyApp/helpfiles/PreProcessing_Procedures.md
+++ b/program/shinyApp/helpfiles/PreProcessing_Procedures.md
@@ -1,4 +1,6 @@
 ## Data Preprocessing
+***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/pre-processing.html" target="_blank">here</a>.
 
 **Step 1: General Data Cleaning**
 

--- a/program/shinyApp/helpfiles/SampleCorr_Choices.md
+++ b/program/shinyApp/helpfiles/SampleCorr_Choices.md
@@ -1,6 +1,7 @@
 ## Correlation method
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/sample-correlation.html" target="_blank">here</a>.
 
 Choose **one** of the following correlation methods. These correlation methods provide 
 insights into different aspects of relationships between variables. Understanding 

--- a/program/shinyApp/helpfiles/SampleCorr_Color.md
+++ b/program/shinyApp/helpfiles/SampleCorr_Color.md
@@ -1,6 +1,7 @@
 ## Color Annotation
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/sample-correlation.html" target="_blank">here</a>.
 
 You can choose **Multiple** options. Each option is a column from the `sample 
 annotation table`. The clustered samples will be colored on the right side by your 

--- a/program/shinyApp/helpfiles/SampleCorr_Downloads.md
+++ b/program/shinyApp/helpfiles/SampleCorr_Downloads.md
@@ -1,6 +1,7 @@
 ## Download Helper
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details.html#features-across-tabs" target="_blank">here</a>.
 
 These buttons serve for various downloading purposes.
 

--- a/program/shinyApp/helpfiles/SigAna_Choices.md
+++ b/program/shinyApp/helpfiles/SigAna_Choices.md
@@ -1,5 +1,8 @@
 ## Significance Analysis Options
 
+***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/significance-analysis.html#main-panel-" target="_blank">here</a>.
+
 **1. Choose Groups to Compare:**
 
 - **Description:**

--- a/program/shinyApp/helpfiles/SigAna_Intersections.md
+++ b/program/shinyApp/helpfiles/SigAna_Intersections.md
@@ -1,6 +1,8 @@
 ## Highlight and Download intersections
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/significance-analysis.html#main-panel-" target="_blank">here</a>.
+
 To allow for a better overview of the intersections, the user can highlight the 
 intersections of interest. You can choose from all available intersections in the 
 `Intersections to highlight` menu. The intersection names shown in the Upset plot above, 

--- a/program/shinyApp/helpfiles/SigAna_Vis.md
+++ b/program/shinyApp/helpfiles/SigAna_Vis.md
@@ -1,6 +1,8 @@
 ## Visualizing Significance Analysis Results Options
 
 ***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/significance-analysis.html#main-panel-" target="_blank">here</a>.
+
 **1. Select Comparisons to Visualize:**
 
 - **Description:**

--- a/program/shinyApp/helpfiles/SingleGene_Options.md
+++ b/program/shinyApp/helpfiles/SingleGene_Options.md
@@ -1,6 +1,8 @@
 ## Single Gene Visualization Options
 
 ---
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/single-gene-visualisations.html#side-panel-" target="_blank">here</a>.
+
 **1. Choose Data Type:**
 
 - **Description:**

--- a/program/shinyApp/helpfiles/SingleGene_Select.md
+++ b/program/shinyApp/helpfiles/SingleGene_Select.md
@@ -1,6 +1,8 @@
 ## Choosing groups for comparison
 
 ---
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details/single-gene-visualisations.html#side-panel-" target="_blank">here</a>.
+
 This option lets you specify how to group the samples based on the annotation categories 
 provided in the sample annotation file. This only has an effect if you have chosen 
 `boxplots_withTesting` as the visualization style.

--- a/program/shinyApp/helpfiles/TakingNotesMD_help.md
+++ b/program/shinyApp/helpfiles/TakingNotesMD_help.md
@@ -1,5 +1,7 @@
 ## Personal Note Taking
 
+***
+💡 **Tip**: For more detailed information, please visit <a href="https://icb-dcm.github.io/cOmicsArt/interface-details.html#features-across-tabs" target="_blank">here</a>.
 
 This Section is here for your Notes. It can be as easy as just a keyword or as complex as an entire figure description or even an entire book (however I do think there are better tools for this).
 To enable possibilities to structure your text, involving headings, bullets points or colored chunks `markdown` syntax can be used. 

--- a/program/shinyApp/helpfiles/helpTab_question.md
+++ b/program/shinyApp/helpfiles/helpTab_question.md
@@ -1,0 +1,7 @@
+## Congrats!
+***
+💡 **Tip**: If you click <a href="https://icb-dcm.github.io/cOmicsArt/" target="_blank">here</a> you will be directed to the correct location within the documentation. Note: Here is the beginning of the documentation.
+
+You found your first question mark. Watch out for these to get immediate help on the
+particular topic the question mark is attached to. They often also direct you to further
+help resources within the documentation.

--- a/program/shinyApp/server.R
+++ b/program/shinyApp/server.R
@@ -80,12 +80,22 @@ server <- function(input,output,session){
   guide_welcome <- Cicerone$
     new(id = "guide", 
         opacity = 0.9,
+        padding = 10,
         keyboard_control = TRUE)$
     step(
       el = "start_tour",
       title = "Welcome to cOmicsArt!",
-      description = "If you need help press the button! If you want to start directly click next and you will be directed to Data selection automatically.",
-    )$
+      position = "right-center",
+      description = HTML("
+      <div style='min-width: 300px; min-height: 150px; padding: 10px;'>
+        <img src='Logo_cOmicsArt_clear.png' alt='cOmicsArt Logo' style='max-width:90%;'>
+        <div style='font-size: 18px; margin-top: 10px;'>
+          <p><i class='fas fa-question-circle'></i> Need help? Press the blue button</p>
+          <p><i class='fas fa-rocket'></i> Want to start directly? Click 'Next'.</p>
+        </div>
+      </div>
+    ")
+  )$
     step(
       el = "tabsetPanel1",
       title = "Welcome to cOmicsArt!",
@@ -97,12 +107,13 @@ server <- function(input,output,session){
   # Start the tour when the "Start Tour" button is clicked
   observeEvent(input$start_tour, {
     print("Star Tour")
+    runjs("document.querySelector('.driver-close-btn').click();")
     guide$init()$start()
   })
   
   observeEvent(input$guide_cicerone_next, {
     print("Next")
-    guide_welcome$move_forward()
+    runjs("document.querySelector('.driver-close-btn').click();")
     showTab(inputId = "tabsetPanel1",target = "Data selection",select = T)
     #showTab(inputId = "tabsetPanel1", target = "Data selection")
   })
@@ -165,6 +176,10 @@ server <- function(input,output,session){
       })
       output$WelcomePage_ui <- renderUI({NULL})
     }
+  })
+  
+  observeEvent(input$NextPanel,{
+    showTab(inputId = "tabsetPanel1",target = "Data selection",select = T)
   })
 
   

--- a/program/shinyApp/server.R
+++ b/program/shinyApp/server.R
@@ -72,7 +72,103 @@ server <- function(input,output,session){
   hideTab(inputId = "tabsetPanel1", target = "Single Gene Visualisations")
   hideTab(inputId = "tabsetPanel1", target = "Enrichment Analysis")
   shinyjs::hide("mainPanel_DataSelection")
+
+# Set Up ad Show user Landing page ----
+# TODO: SetUp cookie usage to land on second page
+  # Define the guide
+  # Note do this in here to avoid setting a global upon close
+  guide_welcome <- Cicerone$
+    new(id = "guide", 
+        opacity = 0.9,
+        keyboard_control = TRUE)$
+    step(
+      el = "start_tour",
+      title = "Welcome to cOmicsArt!",
+      description = "If you need help press the button! If you want to start directly click next and you will be directed to Data selection automatically.",
+    )$
+    step(
+      el = "tabsetPanel1",
+      title = "Welcome to cOmicsArt!",
+      description = "You pressed next - redirection triggered",
+    )
   
+  guide_welcome$init()$start()
+  
+  # Start the tour when the "Start Tour" button is clicked
+  observeEvent(input$start_tour, {
+    print("Star Tour")
+    guide$init()$start()
+  })
+  
+  observeEvent(input$guide_cicerone_next, {
+    print("Next")
+    guide_welcome$move_forward()
+    showTab(inputId = "tabsetPanel1",target = "Data selection",select = T)
+    #showTab(inputId = "tabsetPanel1", target = "Data selection")
+  })
+
+  output$help_tab_info <- renderText({
+    HTML(paste0(
+    "Please select an image to display within the sidebar(left)<br>",
+    "To confirm your selection click the button labelled 'GO show me help!' within the sidebar."
+    ))
+  })
+  
+  output$WelcomePage_ui <- renderUI({
+    imageOutput("WelcomePage")
+  })
+  
+  observeEvent(input$get_help,{
+    if(input$ImageSelect == "WelcomePage"){
+      output$WelcomePage_ui <- renderUI({
+        imageOutput("WelcomePage")
+      })
+      output$WelcomePage <- renderImage({
+        # Path to the image file
+        list(
+          src = "www/WelcomPage.png",
+          contentType = "image/png",
+          width = paste0(input$ImageWidth,"%"), # Adjust as needed
+          height = input$ImageHeight # Adjust as needed
+        )
+      }, deleteFile = FALSE) # Set deleteFile to FALSE to keep the image file
+      output$help_tab_info <- renderText({
+        HTML(
+          paste0(
+            "As you selected the WelcomePage on the **left**, you can see a ccreenshot of the WelcomePage below.<br>",
+            "If you want to see the full documentation, click ",
+            "<a href='https://icb-dcm.github.io/cOmicsArt/' target='_blank'>here</a>",
+            ".<br>or click on the link on the top left of the screen 'Go To Documentation'.<br><br>",
+            "Within cOmicsArt this box will display information depending on the current tab you are in.<br> A tab represents an analysis."
+          )
+        )
+        }
+      )
+    } else if(input$ImageSelect == "YouTube Tutorial"){
+      output$WelcomePage_ui <- renderUI({
+        tags$iframe(
+          width = paste0(input$ImageWidth,"%"), # Adjust as needed
+          height = input$ImageHeight, # Adjust as needed
+          src = "https://www.youtube.com/embed/pTGjtIYQOak",
+          frameborder = "0",
+          allow = "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture",
+          allowfullscreen = TRUE
+        )
+      })
+    } else if(input$ImageSelect == "nothing selected"){
+      output$help_tab_info <- renderText({
+        HTML(paste0(
+          "You have selected 'nothing selected' - hence there is nothing to show<br>.",
+          "Do you want to see something else? Try to select a different Image (Select Image) on the left!<br>",
+          "Did you maybe just press the button?"
+        ))
+      })
+      output$WelcomePage_ui <- renderUI({NULL})
+    }
+  })
+
+  
+
 # Init res_tmp and par_tmp objects if they do not yet exist ----
   if(!exists("res_tmp")){
     res_tmp <<- list()

--- a/program/shinyApp/server.R
+++ b/program/shinyApp/server.R
@@ -102,7 +102,7 @@ server <- function(input,output,session){
       description = "You pressed next - redirection triggered",
     )
   
-  guide_welcome$init()$start()
+   # guide_welcome$init()$start()
   
   # Start the tour when the "Start Tour" button is clicked
   observeEvent(input$start_tour, {

--- a/program/shinyApp/server.R
+++ b/program/shinyApp/server.R
@@ -115,7 +115,6 @@ server <- function(input,output,session){
     print("Next")
     shinyjs::runjs("document.querySelector('.driver-close-btn').click();")
     showTab(inputId = "tabsetPanel1",target = "Data selection",select = T)
-    #showTab(inputId = "tabsetPanel1", target = "Data selection")
   })
 
   output$help_tab_info <- renderText({
@@ -146,7 +145,7 @@ server <- function(input,output,session){
       output$help_tab_info <- renderText({
         HTML(
           paste0(
-            "As you selected the WelcomePage on the **left**, you can see a ccreenshot of the WelcomePage below.<br>",
+"As you selected the WelcomePage on the **left**, you can see a screenshot of the WelcomePage below.<br>",
             "If you want to see the full documentation, click ",
             "<a href='https://icb-dcm.github.io/cOmicsArt/' target='_blank'>here</a>",
             ".<br>or click on the link on the top left of the screen 'Go To Documentation'.<br><br>",

--- a/program/shinyApp/server.R
+++ b/program/shinyApp/server.R
@@ -107,13 +107,13 @@ server <- function(input,output,session){
   # Start the tour when the "Start Tour" button is clicked
   observeEvent(input$start_tour, {
     print("Star Tour")
-    runjs("document.querySelector('.driver-close-btn').click();")
+    shinyjs::runjs("document.querySelector('.driver-close-btn').click();")
     guide$init()$start()
   })
   
   observeEvent(input$guide_cicerone_next, {
     print("Next")
-    runjs("document.querySelector('.driver-close-btn').click();")
+    shinyjs::runjs("document.querySelector('.driver-close-btn').click();")
     showTab(inputId = "tabsetPanel1",target = "Data selection",select = T)
     #showTab(inputId = "tabsetPanel1", target = "Data selection")
   })

--- a/program/shinyApp/server.R
+++ b/program/shinyApp/server.R
@@ -102,7 +102,7 @@ server <- function(input,output,session){
       description = "You pressed next - redirection triggered",
     )
   
-   # guide_welcome$init()$start()
+  guide_welcome$init()$start()
   
   # Start the tour when the "Start Tour" button is clicked
   observeEvent(input$start_tour, {

--- a/program/shinyApp/ui.R
+++ b/program/shinyApp/ui.R
@@ -96,6 +96,10 @@ ui <- shiny::fluidPage(
         width: 90%;
         max-width: 90%;
       }
+      .shinyhelper-container {
+        font-size: 24px;
+        color: darkred !important;
+      }
       #sidebar_data_selection {
           background-color: #70BF4F47;
       }

--- a/program/shinyApp/ui.R
+++ b/program/shinyApp/ui.R
@@ -204,15 +204,18 @@ ui <- shiny::fluidPage(
       column(width=1, tags$img(src = "Logo_cOmicsArt_clear.png", height="100%", width="100%")),
       h1(HTML('<span style="color:#EC0014">c</span><span style="color:#FD8D33">O</span><span style="color:#3897F1">m</span><span style="color:#FFD335">i</span><span style="color:#A208BA">c</span><span style="color:#EF0089">s</span><span style="color:#EC0014">A</span><span style="color:#FD8D33">r</span><span style="color:#3897F1">t</span>'))
   ),
-  splitLayout(
-    cellWidths = c("75%", "10%", "15%"),
-    DownloadReport_ui("DownloadTestModule"),
-    NULL
-  ),
-  splitLayout(
-    cellWidths = c("75%", "10%", "15%"),
-    tags$a(href = "https://icb-dcm.github.io/cOmicsArt/", "Go To Documentation", target = "_blank"),
-    NULL
+  div(
+    id = "UsefulLinks",
+    splitLayout(
+      cellWidths = c("75%", "10%", "15%"),
+      DownloadReport_ui("DownloadTestModule"),
+      NULL
+    ),
+    splitLayout(
+      cellWidths = c("75%", "10%", "15%"),
+      tags$a(href = "https://icb-dcm.github.io/cOmicsArt/", "Go To Documentation", target = "_blank"),
+      NULL
+    )
   ),
 
   tabsetPanel(

--- a/program/shinyApp/ui.R
+++ b/program/shinyApp/ui.R
@@ -50,6 +50,7 @@ library(reshape2)
 source("R/C.R")
 source("R/module_DownloadReport.R",local=T)
 # source the uis for each panel here
+source("R/help_tab/ui.R",local=T)
 source("R/data_selection/ui.R",local=T)
 source("R/pre_processing/ui.R",local=T)
 source("R/pca/ui.R",local=T)
@@ -66,6 +67,7 @@ ui <- shiny::fluidPage(
   # Loading Bars?
   # useWaitress(),
   useWaiter(),
+  use_cicerone(),
   # JS to reset input values
   tags$script("
     Shiny.addCustomMessageHandler('resetValue', function(variableName) {
@@ -218,6 +220,7 @@ ui <- shiny::fluidPage(
     ################################################################################
     # Tab Selection w Upload
     ################################################################################
+    help_tab_panel,
     data_selection_panel,
     pre_processing_panel,
     sampleCorrelation_UI("sample_correlation"),


### PR DESCRIPTION
adresses issues metnioned in #356 
- new tab with help - designed as the other tabs with a guide upon button click or a redirection to Data Selection tab
- links in ?-helpfile to precise location within docs; style changes
- small additionas to docs to highlight the search bar within documentation

Not Done:
- the Panda thing
- additional resource for interpretation. Rethinking might be over the top - user can still google that as well
-- if explicit requested: maybe just add an intepretation site to the documentation to avoid further clutering on user interface