### PR TITLE
PCA Loading Matrix sensible slider values

### DIFF
--- a/program/shinyApp/R/pca/server.R
+++ b/program/shinyApp/R/pca/server.R
@@ -19,6 +19,8 @@ pca_Server <- function(id){
         html = LOADING_SCREEN,
         color="#70BF4F47"
       ),
+      matrix_slider_max = 1,
+      matrix_slider_step = 0.01,
       allow_plot = FALSE
     )
     ns <- session$ns
@@ -181,6 +183,13 @@ pca_Server <- function(id){
         pca_reactives$waiter$hide()
         return(NULL)
       })
+      # Potentially update the slider for the matrix filter
+      isolate(update_slider_values(
+        pca = pca,
+        n_pcs = input$nPCAs_to_look_at %||% 4,
+        current_val = input$filterValue %||% 0.3,
+        session = session
+      ))
 
       # assign res_temp
       res_tmp[[session$token]][["PCA"]] <<- pca

--- a/program/shinyApp/R/pca/server.R
+++ b/program/shinyApp/R/pca/server.R
@@ -55,7 +55,7 @@ pca_Server <- function(id){
           inputId = ns("nPCAs_to_look_at"),
           label = "Number of PC's to include",
           min = 1,
-          max = length(c(colnames(colData(data$data)))),
+          max = length(c(colnames(data$data))),
           value = 4,
           step = 1
         )

--- a/program/shinyApp/R/pca/server.R
+++ b/program/shinyApp/R/pca/server.R
@@ -183,13 +183,6 @@ pca_Server <- function(id){
         pca_reactives$waiter$hide()
         return(NULL)
       })
-      # Potentially update the slider for the matrix filter
-      isolate(update_slider_values(
-        pca = pca,
-        n_pcs = input$nPCAs_to_look_at %||% 4,
-        current_val = input$filterValue %||% 0.3,
-        session = session
-      ))
 
       # assign res_temp
       res_tmp[[session$token]][["PCA"]] <<- pca
@@ -335,6 +328,14 @@ pca_Server <- function(id){
       cutoff <- input$filterValue
       n_pcs <- input$nPCAs_to_look_at %||% 2
       data <- update_data(session$token)$data
+
+      # Potentially update the slider for the matrix filter
+      isolate(update_slider_values(
+        pca = pca,
+        n_pcs = n_pcs,
+        current_val = cutoff,
+        session = session
+      ))
       # Loadings Matrix plot
       pca_reactives$LoadingsMatrix_plot <- plot_loadings_matrix(
         pca = pca,

--- a/program/shinyApp/R/pca/ui.R
+++ b/program/shinyApp/R/pca/ui.R
@@ -210,7 +210,6 @@ pca_main_panel <- function(ns){
             #textOutput(outputId = ns("Loadings_plot_Options_selected_out"), container = pre)
           ),
           uiOutput(outputId = ns("nPCAs_to_look_at_ui")),
-  
           sliderInput(
             inputId = ns("filterValue"),
             label = "absolute Loading threshold to filter entities with low impact",

--- a/program/shinyApp/R/pca/util.R
+++ b/program/shinyApp/R/pca/util.R
@@ -178,12 +178,17 @@ update_slider_values <- function(
   top_5_vals <- tail(sort(abs_loadings, decreasing = FALSE), 5)
   max_val <- max(top_5_vals)
   new_val <- min(top_5_vals)
-  if (max_val > current_val) {
-    return(NULL)
-  }
-  # adjust ne max_value such that it is a "nice" value
+  # adjust new max_value such that it is a "nice" value
   exponent <- floor(log10(max_val))
   max_val <- ceiling(max_val / 10^exponent) * 10^exponent
+  if (max_val > current_val) {
+    updateSliderInput(
+        session = session,
+        inputId = "filterValue",
+        max = max_val
+    )
+    return(NULL)
+  }
   steps <- max_val / 100
   new_val <- floor(new_val / steps) * steps
   message(paste("Updating slider to max", max_val, "step", steps, "value", new_val))

--- a/program/shinyApp/R/pca/util.R
+++ b/program/shinyApp/R/pca/util.R
@@ -162,3 +162,37 @@ pca_ellipses <- function(
   if (!(plot_ellipses)) return(NULL)
   return(stat_ellipse(level = 0.95, linetype = 2, show.legend = FALSE))
 }
+
+update_slider_values <- function(
+  pca,
+  n_pcs,
+  current_val,
+  session
+){
+  # Checks whether the slider of the matrix needs to be adapted
+  n_pcs <- min(n_pcs, ncol(pca$rotation))
+  abs_loadings <- abs(as.matrix(data.frame(
+    entity = row.names(pca$rotation),
+    pca$rotation[, 1:n_pcs]
+  )[,-1]))
+  top_5_vals <- tail(sort(abs_loadings, decreasing = FALSE), 5)
+  max_val <- max(top_5_vals)
+  new_val <- min(top_5_vals)
+  if (max_val > current_val) {
+    return(NULL)
+  }
+  # adjust ne max_value such that it is a "nice" value
+  exponent <- floor(log10(max_val))
+  max_val <- ceiling(max_val / 10^exponent) * 10^exponent
+  steps <- max_val / 100
+  new_val <- floor(new_val / steps) * steps
+  message(paste("Updating slider to max", max_val, "step", steps, "value", new_val))
+  updateSliderInput(
+      session = session,
+      inputId = "filterValue",
+      value = new_val,
+      min = 0,
+      max = max_val,
+      step = steps
+  )
+}


### PR DESCRIPTION
Updating slider such that something is always visible.

Not the most elegant probably but should not provide much of an issue. I checked, it does not trigger an additional plotting (run of `# Update the Loadings Matrix Plot`), but this is anyways run **twice**, something to keep in mind. Most likely happens since entitie anno and pcaData are updated in the same observe