### PR TITLE
Dockerimage based env also now for test

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -6,13 +6,16 @@ name: Build & push Docker image
 # test workflow just pulls the prebuilt image instead.
 on:
   push:
-    # NOTE: docker_for_test is TEMPORARY — added so the build can be verified
-    # on this feature branch before merging. Remove it before merging the PR.
+    # NOTE: docker_for_test + the disabled paths filter below are TEMPORARY —
+    # added so the build can be verified on this feature branch before merging.
+    # Before merging the PR, restore this block to:
+    #     branches: [main, develop]
+    #     paths: [Dockerfile, start.sh, program/renv.lock]
     branches: [main, develop, docker_for_test]
-    paths:
-      - Dockerfile
-      - start.sh
-      - program/renv.lock
+    # paths:
+    #   - Dockerfile
+    #   - start.sh
+    #   - program/renv.lock
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -6,7 +6,9 @@ name: Build & push Docker image
 # test workflow just pulls the prebuilt image instead.
 on:
   push:
-    branches: [main, develop]
+    # NOTE: docker_for_test is TEMPORARY — added so the build can be verified
+    # on this feature branch before merging. Remove it before merging the PR.
+    branches: [main, develop, docker_for_test]
     paths:
       - Dockerfile
       - start.sh

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,21 +1,17 @@
 name: Build & push Docker image
 
-# Build the environment image and push it to Docker Hub ONLY when the
-# environment actually changes (lockfile, Dockerfile, or launcher), plus a
-# manual trigger. Day-to-day app-code changes do NOT rebuild the image — the
-# test workflow just pulls the prebuilt image instead.
+# Build the environment image whenever the environment changes (lockfile,
+# Dockerfile, or launcher) on ANY branch, plus a manual trigger.
+#  - lock-<hash> and <sha> tags are pushed on every branch, so the smoke test
+#    running on a feature branch can pull the freshly-built environment.
+#  - :latest is pushed ONLY from main/develop, so feature branches never
+#    overwrite the image end users pull.
 on:
   push:
-    # NOTE: docker_for_test + the disabled paths filter below are TEMPORARY —
-    # added so the build can be verified on this feature branch before merging.
-    # Before merging the PR, restore this block to:
-    #     branches: [main, develop]
-    #     paths: [Dockerfile, start.sh, program/renv.lock]
-    branches: [main, develop, docker_for_test]
-    # paths:
-    #   - Dockerfile
-    #   - start.sh
-    #   - program/renv.lock
+    paths:
+      - Dockerfile
+      - start.sh
+      - program/renv.lock
   workflow_dispatch:
 
 env:
@@ -28,11 +24,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Short, stable tag derived from the lockfile so the test workflow can
-      # pull the image that exactly matches a given renv.lock.
-      - name: Compute renv.lock hash
-        id: lock
-        run: echo "hash=$(sha256sum program/renv.lock | cut -c1-8)" >> "$GITHUB_OUTPUT"
+      - name: Compute image tags
+        id: meta
+        run: |
+          HASH=$(sha256sum program/renv.lock | cut -c1-8)
+          {
+            echo "tags<<EOF"
+            echo "${IMAGE}:lock-${HASH}"
+            echo "${IMAGE}:${{ github.sha }}"
+            if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+              echo "${IMAGE}:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -50,10 +54,6 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64
           push: true
-          tags: |
-            ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:${{ github.ref_name }}
-            ${{ env.IMAGE }}:lock-${{ steps.lock.outputs.hash }}
-            ${{ env.IMAGE }}:${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,54 @@
+name: Build & push Docker image
+
+# Build the environment image and push it to Docker Hub ONLY when the
+# environment actually changes (lockfile, Dockerfile, or launcher), plus a
+# manual trigger. Day-to-day app-code changes do NOT rebuild the image — the
+# test workflow just pulls the prebuilt image instead.
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - Dockerfile
+      - start.sh
+      - program/renv.lock
+  workflow_dispatch:
+
+env:
+  IMAGE: pauljonasjost/comicsart
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Short, stable tag derived from the lockfile so the test workflow can
+      # pull the image that exactly matches a given renv.lock.
+      - name: Compute renv.lock hash
+        id: lock
+        run: echo "hash=$(sha256sum program/renv.lock | cut -c1-8)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.ref_name }}
+            ${{ env.IMAGE }}:lock-${{ steps.lock.outputs.hash }}
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,13 +1,21 @@
 name: Build & push Docker image
 
-# Build the environment image whenever the environment changes (lockfile,
-# Dockerfile, or launcher) on ANY branch, plus a manual trigger.
-#  - lock-<hash> and <sha> tags are pushed on every branch, so the smoke test
-#    running on a feature branch can pull the freshly-built environment.
-#  - :latest is pushed ONLY from main/develop, so feature branches never
-#    overwrite the image end users pull.
+# Build the environment image when the environment changes (lockfile, Dockerfile
+# or launcher):
+#   - On a pull request -> push a human-trackable  pr-<number>  tag, so the PR's
+#     smoke test can pull exactly this build. Does NOT touch :latest.
+#   - On push to main/develop -> push  :latest  (the image end users pull).
+# NOTE: pull_request runs from a fork do not receive repo secrets, so pushing to
+# Docker Hub only works for PRs from branches within this repository.
 on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - Dockerfile
+      - start.sh
+      - program/renv.lock
   push:
+    branches: [main, develop]
     paths:
       - Dockerfile
       - start.sh
@@ -24,19 +32,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Compute image tags
+      - name: Compute image tag
         id: meta
         run: |
-          HASH=$(sha256sum program/renv.lock | cut -c1-8)
-          {
-            echo "tags<<EOF"
-            echo "${IMAGE}:lock-${HASH}"
-            echo "${IMAGE}:${{ github.sha }}"
-            if [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.ref }}" = "refs/heads/develop" ]; then
-              echo "${IMAGE}:latest"
-            fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "tag=${IMAGE}:pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${IMAGE}:latest" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -54,6 +57,6 @@ jobs:
           file: Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tag }}
           cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max

--- a/.github/workflows/start_check.yaml
+++ b/.github/workflows/start_check.yaml
@@ -1,120 +1,59 @@
 name: Test Shiny App Startup
 
+# Fast smoke test: pull the prebuilt environment image from Docker Hub and
+# check that the CURRENT (checked-out) app code starts inside it. 
 on: [push]
 
 jobs:
-  build:
+  smoke:
     runs-on: ubuntu-latest
-    env:
-      RENV_PATHS_ROOT: ~/.cache/R/renv
-      
+    timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
-    
-    - uses: r-lib/actions/setup-r@v2
-      with:
-        r-version: 4.2.0
-    
-    - name: Restore Renv package cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ${{ env.RENV_PATHS_ROOT }}
-          ./renv/library
-        key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{ inputs.cache-version }}-${{ hashFiles('renv.lock') }}
-        restore-keys: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{ inputs.cache-version }}-
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev libsqlite3-dev libglu1-mesa-dev default-jdk libmagick++-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev
-        sudo apt install curl
-    
-    - name: Install and activate renv
-      shell: Rscript {0}
-      run: |
-        install.packages("renv")
-        print(getwd())
-        renv::restore(lockfile="program/renv.lock")
-        
-    # - name: Get R and OS version
-    #   id: get-version
-    #   run: |
-    #     cat("##[set-output name=os-version;]", sessionInfo()$running, "\n", sep = "")
-    #     cat("##[set-output name=r-version;]", R.Version()$version.string, sep = "")
-    #   shell: Rscript {0}
-      
+      # Pull the image whose tag matches THIS commit's renv.lock, so the app is
+      # tested against exactly the environment the lockfile describes. Falls
+      # back to :latest if that tag isn't published yet (e.g. the build for a
+      # brand-new lock is still running).
+      # TODO let it wait till the other workflow is done (build-image.yml)
+      - name: Resolve and pull image
+        id: img
+        run: |
+          HASH=$(sha256sum program/renv.lock | cut -c1-8)
+          TAG="pauljonasjost/comicsart:lock-$HASH"
+          if docker pull "$TAG"; then
+            echo "image=$TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::$TAG not found, falling back to :latest"
+            docker pull pauljonasjost/comicsart:latest
+            echo "image=pauljonasjost/comicsart:latest" >> "$GITHUB_OUTPUT"
+          fi
 
-#    - name: Setup renv
-#      uses: r-lib/actions/setup-renv@v2
-    
-    # - name: Restore packages
-    #   shell: Rscript {0}
-    #   run: |
-    #     renv::restore()
+      - name: Start app (current code mounted into prebuilt env)
+        run: |
+          docker run -d --name comicsart_app -p 3838:3838 \
+            -e MODE=app \
+            -v "${{ github.workspace }}/program/shinyApp":/srv/shiny-server/shinyApp \
+            "${{ steps.img.outputs.image }}"
 
-#    - name: test specific packages
-#      run: |
-#        Rscript -e 'install.packages("Rcpp")'
-#          Rscript -e 'install.packages("RcppArmadillo")'
-#          Rscript -e 'install.packages("DESeq2")'
+      - name: Wait for the app to respond
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sSf http://localhost:3838 >/dev/null 2>&1; then
+              echo "App responded on attempt $i"
+              exit 0
+            fi
+            echo "waiting for app... ($i)"
+            sleep 5
+          done
+          echo "App did not respond within timeout"
+          exit 1
 
-    - name: Test if Shiny app starts
-      timeout-minutes: 2
-      shell: Rscript {0}
-      run: |
-        install.packages('processx')
-        library(processx)
-        
-        execute_shiny_app <- function() {
-          tryCatch(
-            {
-              # Start the Shiny app in a separate process
-              app_process <- process$new(
-                "Rscript",
-                c("-e", "shiny::runApp('program/shinyApp', launch.browser = FALSE, port = 3838)"),
-                stdout = "|", stderr = "|"
-              )
-              
-              # Wait for a few seconds to allow the app to start
-              Sys.sleep(15)
-              
-              # Check if the process is still running
-              if (app_process$is_alive()) {
-                # Terminate the app if it started successfully
-                app_process$kill()
-                return("Success")
-              } else {
-                # Capture and return the error message if the app failed to start
-                error_message <- app_process$read_error()
-                return(paste("Error:", error_message))
-              }
-            },
-            error = function(e) {
-              return(paste("Error:", e$message))
-            }
-          )
-        }
-        
-        
-        result <- execute_shiny_app()
-        
-            # Check if the result is "failure"
-        if (result == "Success") {
-          cat("Test passed")
-        } else {
-        cat(result)
-           cat("Test failed: Output is 'failure'\n")
-          quit(status = 1)
-        }
-        
-    - name: Save cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.local/share/renv
-          ./renv/library
-        key: ${{ steps.get-version.outputs.os-version }}-${{ steps.get-version.outputs.r-version }}-${{ inputs.cache-version }}-${{ hashFiles('renv.lock') }}
+      - name: Show app logs (always)
+        if: always()
+        run: docker logs comicsart_app || true
 
-
-
+      - name: Clean up
+        if: always()
+        run: docker rm -f comicsart_app || true

--- a/.github/workflows/start_check.yaml
+++ b/.github/workflows/start_check.yaml
@@ -7,35 +7,43 @@ on: [push]
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Generous timeout: if this push changed renv.lock, build-image.yml is
+    # building the matching image in parallel and we wait for it (below).
+    timeout-minutes: 75
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Pull the image whose tag matches THIS commit's renv.lock, so the app is
-      # tested against exactly the environment the lockfile describes. Falls
-      # back to :latest if that tag isn't published yet (e.g. the build for a
-      # brand-new lock is still running).
-      # TODO let it wait till the other workflow is done (build-image.yml)
-      - name: Resolve and pull image
+      # The image tag is derived from THIS commit's renv.lock, so we always test
+      # against exactly the environment the lockfile describes.
+      - name: Resolve image tag
         id: img
+        run: echo "tag=pauljonasjost/comicsart:lock-$(sha256sum program/renv.lock | cut -c1-8)" >> "$GITHUB_OUTPUT"
+
+      # Wait for the matching image to be available. If renv.lock just changed,
+      # build-image.yml is building it now, so we retry until it's pushed
+      # (rather than testing against the wrong environment). Unchanged locks are
+      # already on Docker Hub, so the first pull succeeds immediately.
+      - name: Pull image (wait for build-image.yml if env just changed)
         run: |
-          HASH=$(sha256sum program/renv.lock | cut -c1-8)
-          TAG="pauljonasjost/comicsart:lock-$HASH"
-          if docker pull "$TAG"; then
-            echo "image=$TAG" >> "$GITHUB_OUTPUT"
-          else
-            echo "::warning::$TAG not found, falling back to :latest"
-            docker pull pauljonasjost/comicsart:latest
-            echo "image=pauljonasjost/comicsart:latest" >> "$GITHUB_OUTPUT"
-          fi
+          TAG="${{ steps.img.outputs.tag }}"
+          for i in $(seq 1 120); do
+            if docker pull "$TAG"; then
+              echo "Pulled $TAG"
+              exit 0
+            fi
+            echo "[$i/120] $TAG not on Docker Hub yet (build-image.yml may still be running); retrying in 30s..."
+            sleep 30
+          done
+          echo "Timed out waiting for $TAG — did the image build fail?"
+          exit 1
 
       - name: Start app (current code mounted into prebuilt env)
         run: |
           docker run -d --name comicsart_app -p 3838:3838 \
             -e MODE=app \
             -v "${{ github.workspace }}/program/shinyApp":/srv/shiny-server/shinyApp \
-            "${{ steps.img.outputs.image }}"
+            "${{ steps.img.outputs.tag }}"
 
       - name: Wait for the app to respond
         run: |

--- a/.github/workflows/start_check.yaml
+++ b/.github/workflows/start_check.yaml
@@ -1,44 +1,63 @@
 name: Test Shiny App Startup
 
-# Fast smoke test: pull the prebuilt environment image from Docker Hub and
-# check that the CURRENT (checked-out) app code starts inside it. 
-on: [push]
+# Pull the prebuilt environment image and check the CURRENT app code starts in
+# it. No renv restore here — that cost lives in build-image.yml.
+#   - On a PR that changed the environment -> test the pr-<number> image that
+#     build-image.yml is publishing for this PR (wait for it).
+#   - Otherwise -> test the published :latest image.
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+env:
+  IMAGE: pauljonasjost/comicsart
 
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    # Generous timeout: if this push changed renv.lock, build-image.yml is
-    # building the matching image in parallel and we wait for it (below).
+    # Generous: if this PR changed renv.lock, build-image.yml is building the
+    # matching pr-<number> image in parallel and we wait for it below.
     timeout-minutes: 75
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # need both PR parents to diff against the base
 
-      # The image tag is derived from THIS commit's renv.lock, so we always test
-      # against exactly the environment the lockfile describes.
-      - name: Resolve image tag
+      - name: Resolve image to test
         id: img
-        run: echo "tag=pauljonasjost/comicsart:lock-$(sha256sum program/renv.lock | cut -c1-8)" >> "$GITHUB_OUTPUT"
+        run: |
+          TAG="${IMAGE}:latest"   # default: test against the published environment
+          WAIT=false
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Did this PR change the environment? If so, build-image.yml is
+            # publishing a pr-<n> image and we should test against THAT.
+            if git diff --name-only HEAD^1 HEAD | grep -qE '^(Dockerfile|start\.sh|program/renv\.lock)$'; then
+              TAG="${IMAGE}:pr-${{ github.event.pull_request.number }}"
+              WAIT=true
+            fi
+          fi
+          echo "tag=$TAG"   >> "$GITHUB_OUTPUT"
+          echo "wait=$WAIT" >> "$GITHUB_OUTPUT"
+          echo "Testing against $TAG (wait=$WAIT)"
 
-      # Wait for the matching image to be available. If renv.lock just changed,
-      # build-image.yml is building it now, so we retry until it's pushed
-      # (rather than testing against the wrong environment). Unchanged locks are
-      # already on Docker Hub, so the first pull succeeds immediately.
-      - name: Pull image (wait for build-image.yml if env just changed)
+      - name: Pull the image (wait for the PR build if the env changed)
         run: |
           TAG="${{ steps.img.outputs.tag }}"
-          for i in $(seq 1 120); do
-            if docker pull "$TAG"; then
-              echo "Pulled $TAG"
-              exit 0
-            fi
-            echo "[$i/120] $TAG not on Docker Hub yet (build-image.yml may still be running); retrying in 30s..."
-            sleep 30
-          done
-          echo "Timed out waiting for $TAG — did the image build fail?"
-          exit 1
+          if [ "${{ steps.img.outputs.wait }}" = "true" ]; then
+            for i in $(seq 1 120); do
+              if docker pull "$TAG"; then echo "Pulled $TAG"; exit 0; fi
+              echo "[$i/120] $TAG not on Docker Hub yet (build-image.yml still running?); retrying in 30s..."
+              sleep 30
+            done
+            echo "Timed out waiting for $TAG — did the image build fail?"; exit 1
+          else
+            docker pull "$TAG"
+          fi
 
-      - name: Start app (current code mounted into prebuilt env)
+      - name: Start app (current code mounted into the env image)
         run: |
           docker run -d --name comicsart_app -p 3838:3838 \
             -e MODE=app \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,91 @@
-FROM rocker/shiny:4.2.1
+# syntax=docker/dockerfile:1
+# cOmicsArt — single image, two modes (see start.sh):
+#   MODE=app      -> Shiny app on 3838
+#   MODE=rstudio  -> RStudio Server on 8787 (development)
+#
+# RStudio base (gives us RStudio Server for dev mode). The Shiny app itself
+# runs via shiny::runApp, with the shiny package provided by renv::restore.
+# rocker/rstudio:4.2.1 is amd64-only, so we pin the platform: on Apple Silicon
+# this builds/runs under emulation (Docker Desktop + Rosetta). The whole
+# pipeline (Docker Hub image, GitHub Actions runners) is amd64 anyway.
+FROM --platform=linux/amd64 rocker/rstudio:4.2.1
 
 WORKDIR /srv/shiny-server
 
-ENV RENV_PATHS_ROOT=renv
-ENV RENV_PATHS_LIBRARY=renv/library
+# Restore packages into the global site library so EVERY R session — the app,
+# and any RStudio session for any user — finds them on the default .libPaths()
+# with no renv auto-activation needed.
+ENV RENV_PATHS_CACHE=/srv/shiny-server/renv/cache
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -o Acquire::Retries=5 \
+ && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    # build toolchain (very commonly needed)
+    build-essential \
+    gfortran \
+    make \
+    pkg-config \
     cmake \
+    # networking + crypto (httr/curl/openssl)
+    curl \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    # XML/HTML parsing (xml2/rvest)
+    libxml2-dev \
+    # compression (lots of packages)
+    zlib1g-dev \
+    libbz2-dev \
+    liblzma-dev \
+    # git-backed installs (remotes/devtools)
+    git \
+    libgit2-dev \
+    # database + misc common deps
+    libsqlite3-dev \
+    libpq-dev \
+    # image/plot rendering stack (ggplot, ragg, magick, text)
+    libcairo2-dev \
+    libpng-dev \
+    libjpeg-dev \
+    libtiff5-dev \
+    libfreetype6-dev \
+    libfontconfig1-dev \
+    libharfbuzz-dev \
+    libfribidi-dev \
+    libmagick++-dev \
+    # V8 / JS tooling (some htmlwidgets, etc.)
+    libv8-dev \
+    # spatial / units (often pulled in indirectly)
+    libudunits2-dev \
+    libgdal-dev \
+    libgeos-dev \
+    libproj-dev \
+    # Java (some packages need a JDK)
+    default-jdk \
+    # special dep for nloptr
     libnlopt-dev \
-    && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/*
 
-RUN R -e "install.packages('BiocManager')"
-RUN R -e "BiocManager::install('ggtree', ask = FALSE)"
+# Copy ONLY the lockfile first so the (slow) restore layer is cached when only
+# app code changes later.
+COPY program/renv.lock /srv/shiny-server/renv.lock
 
-COPY program/renv.lock /srv/shiny-server/
-RUN R -e "install.packages('renv'); renv::restore()"
+# Restore the locked environment into the global site library.
+# BiocManager is installed first so renv can resolve the 50 Bioconductor pkgs.
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/srv/shiny-server/renv/cache \
+    R -e "install.packages(c('renv','BiocManager'), repos='https://cloud.r-project.org'); \
+          BiocManager::install(version='3.16', ask=FALSE, update=FALSE); \
+          renv::restore(lockfile='/srv/shiny-server/renv.lock', \
+                        library='/usr/local/lib/R/site-library', prompt=FALSE)"
 
+# Now copy the frequently-changing app code (baked default; overridden by a
+# volume mount in dev/CI).
 COPY program/shinyApp /srv/shiny-server/shinyApp
 
-EXPOSE 3838
+# Launcher that switches between app and rstudio modes.
+COPY start.sh /usr/local/bin/start.sh
+RUN chmod +x /usr/local/bin/start.sh
 
-CMD ["R", "-e", "shiny::runApp('/srv/shiny-server/shinyApp', host='0.0.0.0', port=3838)"]
+EXPOSE 3838 8787
 
+ENTRYPOINT ["/usr/local/bin/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,11 @@ RUN --mount=type=cache,target=/var/cache/apt \
           renv::restore(lockfile='/srv/shiny-server/renv.lock', \
                         library='/usr/local/lib/R/site-library', prompt=FALSE)"
 
+# Register R's shared library with the dynamic loader so RStudio's rsession
+# can always find libR.so (otherwise dev mode fails with "Unable to connect
+# to service" / "libR.so: cannot open shared object file").
+RUN echo "/usr/local/lib/R/lib" > /etc/ld.so.conf.d/libR.conf && ldconfig
+
 # Now copy the frequently-changing app code (baked default; overridden by a
 # volume mount in dev/CI).
 COPY program/shinyApp /srv/shiny-server/shinyApp

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,10 @@ WORKDIR /srv/shiny-server
 # and any RStudio session for any user — finds them on the default .libPaths()
 # with no renv auto-activation needed.
 ENV RENV_PATHS_CACHE=/srv/shiny-server/renv/cache
+# Install packages directly into the target library (no isolated staging lib),
+# so each dependency is visible to the packages built after it. Avoids
+# "there is no package called 'magrittr'" type failures during restore.
+ENV RENV_CONFIG_INSTALL_TRANSACTIONAL=FALSE
 
 RUN apt-get update -o Acquire::Retries=5 \
  && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,3 +98,5 @@ RUN chmod +x /usr/local/bin/start.sh
 EXPOSE 3838 8787
 
 ENTRYPOINT ["/usr/local/bin/start.sh"]
+
+# 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,6 +116,24 @@ Shiny app.
 Ensure Docker is installed on your system. You can download and install Docker from 
 [Docker's official website](https://www.docker.com/get-started).
 
+<div class="disclaimer" style="background-color:#fff0bf; color: black; border: 2px solid #ffcf30; border-radius: 8px; padding:0.2em;">
+<span>
+<p style='margin-top:1em; text-align:left ;margin-left:1em;'>
+<b>Apple Silicon (M1/M2/M3) users:</b> The image is built for the
+<code>linux/amd64</code> architecture and runs under emulation on Apple
+Silicon. <b>App mode works out of the box.</b> For the <b>development
+(RStudio) mode</b> you must enable Apple's Virtualization framework and
+Rosetta in Docker Desktop, otherwise RStudio will show
+<i>"Unable to connect to service"</i>:
+<br/><br/>
+Docker Desktop &rarr; <b>Settings</b> &rarr; <b>General</b> &rarr; set
+<b>Virtual Machine Manager (VMM)</b> to <b>Apple Virtualization
+framework</b> &rarr; tick <b>"Use Rosetta for x86_64/amd64 emulation on
+Apple Silicon"</b> &rarr; <b>Apply &amp; Restart</b>. Requires macOS 13
+(Ventura) or newer.
+</p></span>
+</div>
+
 ## Steps to Install and Run the Shiny App
 
 ### 2. Pull the Docker Image
@@ -126,17 +144,24 @@ Open a terminal or command prompt and use the following command to pull the Dock
 docker pull pauljonasjost/comicsart:latest
 ```
 
-### 3. Run the Docker Container
+### 3. Run the Docker Container (App mode)
 
 After pulling the image, you can run the Docker container with the following command:
 
 ```bash
-docker run -p 3838:3838 pauljonasjost/comicsart:latest
+docker run --rm -p 3838:3838 pauljonasjost/comicsart:latest
 ```
 
 This command does the following:
+- `--rm` removes the container automatically when you stop it.
 - `-p 3838:3838` maps port 3838 in the Docker container to port 3838 on your local machine.
 - `pauljonasjost/comicsart:latest` specifies the Docker image to run.
+
+The image supports two modes, selected with the `MODE` environment
+variable: `MODE=app` (the default, shown above) runs the Shiny app, and
+`MODE=rstudio` starts an RStudio Server for development (see
+[Development mode (RStudio)](#development-mode-rstudio) below). Because
+`app` is the default, no `-e MODE=...` flag is needed to run the app.
 
 ### 4. Access the Shiny App
 
@@ -160,20 +185,58 @@ docker pull pauljonasjost/comicsart:latest
 
 Then follow the steps to run the updated image.
 
-### 6. Access the environment through docker
-To enter the Docker container and use the same environment as the app:
+## Development mode (RStudio)
+
+The same image can start an **RStudio Server**, giving you the app's
+fully preloaded R environment inside a browser-based IDE. This is the
+recommended way to develop or debug the app without setting up renv
+locally.
+
+> **Apple Silicon:** development mode requires the Apple Virtualization
+> framework + Rosetta to be enabled first — see the note under
+> [Install Docker](#1--install-docker).
+
+Clone the repository (so your edits are saved to your machine), then
+start the container in `rstudio` mode with your local `program/` folder
+mounted into it:
 
 ```bash
-docker run -it --rm pauljonasjost/comicsart:latest bash
-```
-Then, inside the container:
-```bash
-R
-```
-If you want to have changed files save, e.g., during app development ensure to mount into the docker:
-```
-git clone  https://github.com/icb-dcm/cOmicsArt.git
+git clone https://github.com/icb-dcm/cOmicsArt.git
 cd cOmicsArt
+
+docker run --rm -p 8787:8787 \
+  -e MODE=rstudio \
+  -e PASSWORD=yourpassword \
+  -v "$PWD/program":/home/rstudio/project \
+  pauljonasjost/comicsart:latest
+```
+
+This does the following:
+- `-p 8787:8787` maps RStudio Server's port to your machine.
+- `-e MODE=rstudio` starts RStudio Server instead of the app.
+- `-e PASSWORD=yourpassword` sets the login password (choose your own).
+- `-v "$PWD/program":/home/rstudio/project` mounts your local `program/`
+  folder into the container at `~/project`, so any changes you make are
+  written back to your machine.
+
+Then open [http://localhost:8787](http://localhost:8787) and log in with
+username `rstudio` and the password you set. Your mounted code is in the
+`project/` folder. To launch the app from within RStudio:
+
+```r
+shiny::runApp("project/shinyApp")
+```
+
+Because the environment is baked into the image, packages such as
+`DESeq2` and `ggtree` load immediately — no `renv::restore()` needed.
+
+<details>
+<summary>Alternative: plain shell / VS Code Dev Containers</summary>
+
+If you prefer a terminal or VS Code instead of RStudio, you can open a
+shell in the same environment:
+
+```bash
 docker run -it --rm \
   -v "$PWD":/workspace \
   -w /workspace \
@@ -181,16 +244,12 @@ docker run -it --rm \
   pauljonasjost/comicsart:latest bash
 ```
 
-Note, for having an IDE and not just plain R a simple option is to use VS Code + Dev Containers:
-1. Start the container
-2. Open VS Code
-3. Install the Dev Containers extension
-4. Open the command palette
-5. Select: Dev Containers: Attach to Running Container...
+For an IDE, use VS Code + the **Dev Containers** extension: start the
+container, then in VS Code open the command palette and select
+*Dev Containers: Attach to Running Container...*. Open your mounted local
+folder so saved changes persist on your machine.
 
-This allows you to browse the file structure within the container, open a terminal inside it, and run R directly in the Docker environment.
-
-Use the mounted local repository approach above, then open that local folder in VS Code to ensure local saved changes.
+</details>
 
 
 ### Troubleshooting
@@ -206,5 +265,10 @@ If you encounter issues, consider the following tips:
   Then access the app at `http://localhost:8888`.
 
 - **Permissions Issues**: On Linux, you may need to use `sudo` for Docker commands.
+
+- **RStudio "Unable to connect to service" (Apple Silicon)**: Development
+  mode needs Docker Desktop's Apple Virtualization framework + Rosetta
+  enabled (Settings → General → VMM: *Apple Virtualization framework* →
+  *Use Rosetta for x86_64/amd64 emulation*). App mode is unaffected.
 
 .....

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -235,14 +235,18 @@ Because the environment is baked into the image, packages such as
 The R environment is tracked in `program/renv.lock`, and the Docker image
 is rebuilt from it automatically (see the image-build workflow). The image
 is set up so the `rstudio` user can install packages directly and renv can
-record them. From **development mode** above, in the RStudio Console:
+record them. (note no `renv::init() or restore` required. From **development mode** above, in the RStudio Console:
 
-1. Install the package (installs into the shared library, usable at once):
+1. Install the package:
 
    ```r
-   install.packages("e1071")            # a CRAN package
+   lib <- path.expand("~/R/dev-library"); dir.create(lib, recursive = TRUE, showWarnings = FALSE)
+   .libPaths(c(lib, .libPaths()))
+   Sys.setenv(RENV_PATHS_CACHE = path.expand("~/.cache/R/renv"))
+   # Then install your package, e.g.:
+   # install.packages("e1071")            # a CRAN package
    # for a Bioconductor package instead: BiocManager::install("somePkg")
-   library(e1071)                        # quick check it loads
+   # library(e1071)                        # quick check it loads
    ```
 
 2. Record it — and its dependencies — into the lockfile:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -230,6 +230,43 @@ shiny::runApp("project/shinyApp")
 Because the environment is baked into the image, packages such as
 `DESeq2` and `ggtree` load immediately — no `renv::restore()` needed.
 
+### Adding a new R package
+
+The R environment is tracked in `program/renv.lock`, and the Docker image
+is rebuilt from it automatically (see the image-build workflow). The image
+is set up so the `rstudio` user can install packages directly and renv can
+record them. From **development mode** above, in the RStudio Console:
+
+1. Install the package (installs into the shared library, usable at once):
+
+   ```r
+   install.packages("e1071")            # a CRAN package
+   # for a Bioconductor package instead: BiocManager::install("somePkg")
+   library(e1071)                        # quick check it loads
+   ```
+
+2. Record it — and its dependencies — into the lockfile:
+
+   ```r
+   renv::snapshot(project  = "~/project",
+                  lockfile = "~/project/renv.lock",
+                  type     = "all",
+                  exclude  = c("renv", "BiocManager"))
+   ```
+
+3. Back on your machine, review and commit the lockfile change:
+
+   ```bash
+   git diff program/renv.lock            # should add your package (+ its deps)
+   git add program/renv.lock
+   git commit -m "Add e1071"
+   git push
+   ```
+
+On push, the image is rebuilt from the updated `renv.lock` and the startup
+test runs against it. Afterwards, `docker pull` the refreshed image to use
+the new package in the container.
+
 <details>
 <summary>Alternative: plain shell / VS Code Dev Containers</summary>
 

--- a/program/renv.lock
+++ b/program/renv.lock
@@ -24,7 +24,7 @@
       },
       {
         "Name": "CRAN",
-        "URL": "https://p3m.dev/cran/2022-10-28"
+        "URL": "https://cloud.r-project.org"
       }
     ]
   },

--- a/program/renv.lock
+++ b/program/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.2.0",
+    "Version": "4.2.1",
     "Repositories": [
       {
         "Name": "BioCsoft",
@@ -24,7 +24,7 @@
       },
       {
         "Name": "CRAN",
-        "URL": "https://cran.rstudio.com"
+        "URL": "https://p3m.dev/cran/2022-10-28"
       }
     ]
   },
@@ -106,13 +106,13 @@
     },
     "BiocManager": {
       "Package": "BiocManager",
-      "Version": "1.30.23",
+      "Version": "1.30.19",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "47e968dfe563c1b22c2e20a067ec21d5"
+      "Hash": "726b3bc83ff8e0c35c7efdb74a462b0d"
     },
     "BiocParallel": {
       "Package": "BiocParallel",
@@ -449,6 +449,17 @@
         "utils"
       ],
       "Hash": "5e060cdefe5ae8635ebb788c9e4f239e"
+    },
+    "KernSmooth": {
+      "Package": "KernSmooth",
+      "Version": "2.23-20",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "stats"
+      ],
+      "Hash": "8dcfa99b14c296bc9f1fd64d52fd3ce7"
     },
     "MASS": {
       "Package": "MASS",
@@ -1184,6 +1195,19 @@
       ],
       "Hash": "bf366c80e2b55a5383b4af8fa2a10b74"
     },
+    "class": {
+      "Package": "class",
+      "Version": "7.3-20",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "MASS",
+        "R",
+        "stats",
+        "utils"
+      ],
+      "Hash": "da09d82223e669d270e47ed24ac8686e"
+    },
     "cli": {
       "Package": "cli",
       "Version": "3.6.2",
@@ -1535,6 +1559,16 @@
       ],
       "Hash": "451e5edf411987991ab6a5410c45011f"
     },
+    "docopt": {
+      "Package": "docopt",
+      "Version": "0.7.1",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "methods"
+      ],
+      "Hash": "e9eeef7931ee99ca0093f3f20b88e09b"
+    },
     "downlit": {
       "Package": "downlit",
       "Version": "0.4.4",
@@ -1588,6 +1622,22 @@
         "vctrs"
       ],
       "Hash": "fedd9d00c2944ff00a0e2696ccf048ec"
+    },
+    "e1071": {
+      "Package": "e1071",
+      "Version": "1.7-12",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "class",
+        "grDevices",
+        "graphics",
+        "methods",
+        "proxy",
+        "stats",
+        "utils"
+      ],
+      "Hash": "0d776df7577206e100c2c4b508208b10"
     },
     "edgeR": {
       "Package": "edgeR",
@@ -1748,6 +1798,19 @@
         "utils"
       ],
       "Hash": "618609b42c9406731ead03adf5379850"
+    },
+    "foreign": {
+      "Package": "foreign",
+      "Version": "0.8-82",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "methods",
+        "stats",
+        "utils"
+      ],
+      "Hash": "32b25c97ce306a760c4d9f787991b5d9"
     },
     "formatR": {
       "Package": "formatR",
@@ -2574,6 +2637,14 @@
       ],
       "Hash": "88e1f52195c7b500f19bc0c0f536ed1e"
     },
+    "littler": {
+      "Package": "littler",
+      "Version": "0.3.16",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "OS_type": "unix",
+      "Hash": "9c61d9adafa2370b132ea95c691ed314"
+    },
     "lme4": {
       "Package": "lme4",
       "Version": "1.1-35.1",
@@ -3223,6 +3294,18 @@
       ],
       "Hash": "0d8a15c9d000970ada1ab21405387dee"
     },
+    "proxy": {
+      "Package": "proxy",
+      "Version": "0.4-27",
+      "Source": "Repository",
+      "Repository": "RSPM",
+      "Requirements": [
+        "R",
+        "stats",
+        "utils"
+      ],
+      "Hash": "e0ef355c12942cf7a6b91a6cfaea8b3e"
+    },
     "ps": {
       "Package": "ps",
       "Version": "1.7.5",
@@ -3472,6 +3555,19 @@
         "xml2"
       ],
       "Hash": "7b153c746193b143c14baa072bae4e27"
+    },
+    "rpart": {
+      "Package": "rpart",
+      "Version": "4.1.16",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "grDevices",
+        "graphics",
+        "stats"
+      ],
+      "Hash": "ea3ca1d9473daabb3cd0f1b4f974c1ed"
     },
     "rprojroot": {
       "Package": "rprojroot",
@@ -3831,6 +3927,19 @@
         "R"
       ],
       "Hash": "5f5a7629f956619d519205ec475fe647"
+    },
+    "spatial": {
+      "Package": "spatial",
+      "Version": "7.3-15",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "graphics",
+        "stats",
+        "utils"
+      ],
+      "Hash": "c23666fdb7789c8a45e65340bb334607"
     },
     "stringi": {
       "Package": "stringi",

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Selects what the container does at runtime.
+#   MODE=app      -> run the Shiny app on port 3838 (default)
+#   MODE=rstudio  -> run RStudio Server on port 8787 (rocker's /init)
+MODE="${MODE:-app}"
+
+if [ "$MODE" = "app" ]; then
+  echo "Starting Shiny app on port 3838"
+  exec R -e "shiny::runApp('/srv/shiny-server/shinyApp', host = '0.0.0.0', port = 3838)"
+elif [ "$MODE" = "rstudio" ]; then
+  echo "Starting RStudio Server on port 8787 (user: rstudio)"
+  exec /init
+else
+  echo "Unknown MODE: '$MODE'. Use MODE=app or MODE=rstudio." >&2
+  exit 1
+fi


### PR DESCRIPTION
addresses #571 

The app's R environment is shipped now as a Docker image (pauljonasjost/comicsart) built from renv.lock 
— no local renv restore needed.

For the github actions now 2 workflows:

- build-image.yml — rebuilds the image only when the environment changes (renv.lock, Dockerfile, or start.sh), on any branch. It pushes a lock-<hash> tag (matched to the lockfile) and a <sha> tag on every branch; :latest Docker tag  is updated only from main/develop.
- start_check.yaml — runs on every push. It pulls the image whose lock-<hash> matches the current renv.lock (waiting for build-image.yml to finish if the lock just changed), mounts the checked-out app code into it, and smoke-tests that the app starts. - Fast image pull take ~1 minute, then test duration (at the moment just start of the app)

Net effect: change a package → push → the matching image builds and the smoke test runs against it; merging to main/develop publishes that environment as `:latest`

For Local use and development (to also use the docker-based env) - same image, two modes via MODE:

App mode (default): 
docker run --rm -p 3838:3838 pauljonasjost/comicsart:latest 
http://localhost:3838/
Development / RStudio mode: 
docker run --rm -p 8787:8787 -e MODE=rstudio -e PASSWORD=… -v "$PWD/program":/home/rstudio/project pauljonasjost/comicsart:latest
http://localhost:8787/ (user rstudio)

The latest tag should be inline with what is on develop